### PR TITLE
Icon Platform M+ MIDI Remote

### DIFF
--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -1,16 +1,16 @@
 
-function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
-    var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-        columnIndex * 7 + rowIndex * 56]
+// function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
+//     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+//         columnIndex * 7 + rowIndex * 56]
 
-    var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
-    // console.log("display:" + text)
-    for (var i = 0; i < 7; ++i)
-        data.push(text.charCodeAt(i))
-    data.push(0xf7)
+//     var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
+//     // console.log("display:" + text)
+//     for (var i = 0; i < 7; ++i)
+//         data.push(text.charCodeAt(i))
+//     data.push(0xf7)
 
-    return data
-}
+//     return data
+// }
 
 
 function setTextOfColumn(columnIndex, col_text, original_text) {
@@ -29,31 +29,37 @@ function setTextOfColumn(columnIndex, col_text, original_text) {
     return new_text
 }
 
-
-function displaySetTextOfLine(rowIndex, textString) {
-    var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-        rowIndex * 56]
+function setTextOfLine(textString) {
     var blank = Array(56).join(" ")
     var text = (textString + blank).slice(0, 56) // ensure to always clear the entire row
-    // console.log("display:" + text)
-    for (var i = 0; i < 56; ++i)
-        data.push(text.charCodeAt(i))
-    data.push(0xf7)
 
-    return data
+    return text
 }
+
+// function displaySetTextOfLine(rowIndex, textString) {
+//     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+//         rowIndex * 56]
+//     var blank = Array(56).join(" ")
+//     var text = (textString + blank).slice(0, 56) // ensure to always clear the entire row
+//     // console.log("display:" + text)
+//     for (var i = 0; i < 56; ++i)
+//         data.push(text.charCodeAt(i))
+//     data.push(0xf7)
+
+//     return data
+// }
 
 /**
  * @param {MR_ActiveDevice} activeDevice
  * @param {MR_DeviceMidiOutput} outPort
  */
-function resetDisplay(activeDevice, outPort) {
-    for (var i = 0; i < 8; ++i) {
-        for (var k = 0; k < 2; ++k) {
-            outPort.sendMidi(activeDevice, displaySetTextOfColumn(i, k, "       "))
-        }
-    }
-}
+// function resetDisplay(activeDevice, outPort) {
+//     for (var i = 0; i < 8; ++i) {
+//         for (var k = 0; k < 2; ++k) {
+//             outPort.sendMidi(activeDevice, displaySetTextOfColumn(i, k, "       "))
+//         }
+//     }
+// }
 
 function makeLabel(value, length) {
     // console.log("makeLabel:" + value)
@@ -82,13 +88,14 @@ function makeLabel(value, length) {
 }
 
 module.exports = {
-    sysex: {
-        displaySetTextOfColumn: displaySetTextOfColumn,
-        displaySetTextOfLine: displaySetTextOfLine
-    },
+    // sysex: {
+    //     displaySetTextOfColumn: displaySetTextOfColumn,
+    //     displaySetTextOfLine: displaySetTextOfLine
+    // },
     display: {
-        reset: resetDisplay,
+        // reset: resetDisplay,
         makeLabel: makeLabel,
-        setTextOfColumn: setTextOfColumn
+        setTextOfColumn: setTextOfColumn,
+        setTextOfLine: setTextOfLine
     }
 }

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -1,0 +1,58 @@
+
+function make_Sysex_displayActivateLayoutByIndex(layoutIndex) {
+    return [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0a, 0x01,
+        0x01, layoutIndex,
+        0xf7]
+}
+
+function make_Sysex_displayActivateLayoutKnob() {
+    return make_Sysex_displayActivateLayoutByIndex(0x01)
+}
+
+function make_Sysex_displaySetTextOfColumn(columnIndex, textFieldIndex, textString) {
+    var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+        columnIndex * 7 + textFieldIndex * 56]
+    //0xF0 0x00 0x00 0x66 0x14 0x12 ' + pos + ' ' + text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^\x00-\x7F]/g, "?").split('').map(x => x.charCodeAt(0)).join(' ') + ' 0xF7
+
+    var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
+    for (var i = 0; i < 7; ++i)
+        data.push(text.charCodeAt(i))
+
+
+    //data.push(0)
+    data.push(0xf7)
+
+    return data
+}
+
+function make_Sysex_setDisplayValueOfColumn(columnIndex, objectIndex, value) {
+    // return [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0a, 0x01,
+    //    0x02, columnIndex, 0x03, objectIndex, value, 0xf7]
+    return [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+        columnIndex * 7 + objectIndex * 56, value]
+}
+
+/**
+ * @param {MR_ActiveDevice} activeDevice
+ * @param {MR_DeviceMidiOutput} outPort
+ */
+function resetDisplay(activeDevice, outPort) {
+    outPort.sendMidi(activeDevice, make_Sysex_displayActivateLayoutKnob())
+    for (var i = 0; i < 8; ++i) {
+        for (var k = 0; k < 2; ++k) {
+            outPort.sendMidi(activeDevice, make_Sysex_displaySetTextOfColumn(i, k, "       "))
+        }
+    }
+}
+
+module.exports = {
+    sysex: {
+        displayActivateLayoutByIndex: make_Sysex_displayActivateLayoutByIndex,
+        displayActivateLayoutKnob: make_Sysex_displayActivateLayoutKnob,
+        displaySetTextOfColumn: make_Sysex_displaySetTextOfColumn,
+        setDisplayValueOfColumn: make_Sysex_setDisplayValueOfColumn,
+    },
+    display: {
+        reset: resetDisplay
+    }
+}

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -1,18 +1,3 @@
-
-// function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
-//     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-//         columnIndex * 7 + rowIndex * 56]
-
-//     var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
-//     // console.log("display:" + text)
-//     for (var i = 0; i < 7; ++i)
-//         data.push(text.charCodeAt(i))
-//     data.push(0xf7)
-
-//     return data
-// }
-
-
 function setTextOfColumn(columnIndex, col_text, original_text) {
     var col = columnIndex * 7
     var text = (col_text + '       ').slice(0, 7) // ensure to always clear a column
@@ -35,31 +20,6 @@ function setTextOfLine(textString) {
 
     return text
 }
-
-// function displaySetTextOfLine(rowIndex, textString) {
-//     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-//         rowIndex * 56]
-//     var blank = Array(56).join(" ")
-//     var text = (textString + blank).slice(0, 56) // ensure to always clear the entire row
-//     // console.log("display:" + text)
-//     for (var i = 0; i < 56; ++i)
-//         data.push(text.charCodeAt(i))
-//     data.push(0xf7)
-
-//     return data
-// }
-
-/**
- * @param {MR_ActiveDevice} activeDevice
- * @param {MR_DeviceMidiOutput} outPort
- */
-// function resetDisplay(activeDevice, outPort) {
-//     for (var i = 0; i < 8; ++i) {
-//         for (var k = 0; k < 2; ++k) {
-//             outPort.sendMidi(activeDevice, displaySetTextOfColumn(i, k, "       "))
-//         }
-//     }
-// }
 
 function makeLabel(value, length) {
     // console.log("makeLabel:" + value)
@@ -88,10 +48,6 @@ function makeLabel(value, length) {
 }
 
 module.exports = {
-    // sysex: {
-    //     displaySetTextOfColumn: displaySetTextOfColumn,
-    //     displaySetTextOfLine: displaySetTextOfLine
-    // },
     display: {
         // reset: resetDisplay,
         makeLabel: makeLabel,

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -12,6 +12,24 @@ function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
     return data
 }
 
+
+function setTextOfColumn(columnIndex, col_text, original_text) {
+    var col = columnIndex * 7
+    var text = (col_text + '       ').slice(0, 7) // ensure to always clear a column
+
+    //  original_text must be the full width of the display when setting a column
+    // so pad with spaces if it isn't
+    var new_text = original_text.slice(0, 56)
+    var length = new_text.length
+    while (length++ < 56)
+        new_text = new_text.concat(" ")
+
+    new_text = new_text.substring(0, col) + text + new_text.substring(col + 7, new_text.length);
+
+    return new_text
+}
+
+
 function displaySetTextOfLine(rowIndex, textString) {
     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
         rowIndex * 56]
@@ -70,6 +88,7 @@ module.exports = {
     },
     display: {
         reset: resetDisplay,
-        makeLabel: makeLabel
+        makeLabel: makeLabel,
+        setTextOfColumn: setTextOfColumn
     }
 }

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -16,9 +16,9 @@ function displaySetTextOfLine(rowIndex, textString) {
     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
         rowIndex * 56]
     var blank = Array(56).join(" ")
-    var text = (textString + blank).slice(0, 50) // ensure to always clear the entire row
+    var text = (textString + blank).slice(0, 56) // ensure to always clear the entire row
     // console.log("display:" + text)
-    for (var i = 0; i < 50; ++i)
+    for (var i = 0; i < 56; ++i)
         data.push(text.charCodeAt(i))
     data.push(0xf7)
 

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -4,7 +4,7 @@ function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
         columnIndex * 7 + rowIndex * 56]
 
     var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
-    console.log("display:"+text)
+    // console.log("display:" + text)
     for (var i = 0; i < 7; ++i)
         data.push(text.charCodeAt(i))
     data.push(0xf7)
@@ -17,7 +17,7 @@ function displaySetTextOfLine(rowIndex, textString) {
         rowIndex * 56]
     var blank = Array(56).join(" ")
     var text = (textString + blank).slice(0, 50) // ensure to always clear the entire row
-    console.log("display:"+text)
+    // console.log("display:" + text)
     for (var i = 0; i < 50; ++i)
         data.push(text.charCodeAt(i))
     data.push(0xf7)
@@ -37,12 +37,39 @@ function resetDisplay(activeDevice, outPort) {
     }
 }
 
+function makeLabel(value, length) {
+    // console.log("makeLabel:" + value)
+    // Do nothing if the label is already short enough
+    if (value.length <= length) {
+        return value
+    }
+
+    // If to long shorten it by removing vowels and making it CamelCase to remove spaces
+    var words = value.split(" ");
+    var label = "";
+
+    for (var i = 0, len = words.length; i < len; i++) {
+
+        var currentStr = words[i];
+
+        var tempStr = currentStr
+
+        // convert first letter to upper case and remove all vowels after first letter
+        tempStr = tempStr.substr(0, 1).toUpperCase() + tempStr.substr(1).replace(/[aeiou]/gi, '');
+
+        label += tempStr;
+
+    }
+    return label.slice(0, length); // Remove vowels and shorten to 6 char label
+}
+
 module.exports = {
     sysex: {
         displaySetTextOfColumn: displaySetTextOfColumn,
         displaySetTextOfLine: displaySetTextOfLine
     },
     display: {
-        reset: resetDisplay
+        reset: resetDisplay,
+        makeLabel: makeLabel
     }
 }

--- a/icon/platformmplus/helper.js
+++ b/icon/platformmplus/helper.js
@@ -1,35 +1,28 @@
 
-function make_Sysex_displayActivateLayoutByIndex(layoutIndex) {
-    return [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0a, 0x01,
-        0x01, layoutIndex,
-        0xf7]
-}
-
-function make_Sysex_displayActivateLayoutKnob() {
-    return make_Sysex_displayActivateLayoutByIndex(0x01)
-}
-
-function make_Sysex_displaySetTextOfColumn(columnIndex, textFieldIndex, textString) {
+function displaySetTextOfColumn(columnIndex, rowIndex, textString) {
     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-        columnIndex * 7 + textFieldIndex * 56]
-    //0xF0 0x00 0x00 0x66 0x14 0x12 ' + pos + ' ' + text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^\x00-\x7F]/g, "?").split('').map(x => x.charCodeAt(0)).join(' ') + ' 0xF7
+        columnIndex * 7 + rowIndex * 56]
 
     var text = (textString + '       ').slice(0, 7) // ensure to always clear a column
+    console.log("display:"+text)
     for (var i = 0; i < 7; ++i)
         data.push(text.charCodeAt(i))
-
-
-    //data.push(0)
     data.push(0xf7)
 
     return data
 }
 
-function make_Sysex_setDisplayValueOfColumn(columnIndex, objectIndex, value) {
-    // return [0xf0, 0x00, 0x20, 0x29, 0x02, 0x0a, 0x01,
-    //    0x02, columnIndex, 0x03, objectIndex, value, 0xf7]
-    return [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-        columnIndex * 7 + objectIndex * 56, value]
+function displaySetTextOfLine(rowIndex, textString) {
+    var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+        rowIndex * 56]
+    var blank = Array(56).join(" ")
+    var text = (textString + blank).slice(0, 50) // ensure to always clear the entire row
+    console.log("display:"+text)
+    for (var i = 0; i < 50; ++i)
+        data.push(text.charCodeAt(i))
+    data.push(0xf7)
+
+    return data
 }
 
 /**
@@ -37,20 +30,17 @@ function make_Sysex_setDisplayValueOfColumn(columnIndex, objectIndex, value) {
  * @param {MR_DeviceMidiOutput} outPort
  */
 function resetDisplay(activeDevice, outPort) {
-    outPort.sendMidi(activeDevice, make_Sysex_displayActivateLayoutKnob())
     for (var i = 0; i < 8; ++i) {
         for (var k = 0; k < 2; ++k) {
-            outPort.sendMidi(activeDevice, make_Sysex_displaySetTextOfColumn(i, k, "       "))
+            outPort.sendMidi(activeDevice, displaySetTextOfColumn(i, k, "       "))
         }
     }
 }
 
 module.exports = {
     sysex: {
-        displayActivateLayoutByIndex: make_Sysex_displayActivateLayoutByIndex,
-        displayActivateLayoutKnob: make_Sysex_displayActivateLayoutKnob,
-        displaySetTextOfColumn: make_Sysex_displaySetTextOfColumn,
-        setDisplayValueOfColumn: make_Sysex_setDisplayValueOfColumn,
+        displaySetTextOfColumn: displaySetTextOfColumn,
+        displaySetTextOfLine: displaySetTextOfLine
     },
     display: {
         reset: resetDisplay

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -43,7 +43,8 @@ function Helper_updateDisplay(/** @type {string} */idRow1, /** @type {string} */
   } else {
     // Update display if it has changed
     if ((newRow1 !== prevRow1) || (newRow2 !== prevRow2) || (activeDisplayType !== displayType)) {
-       console.log("Rows Display update" + newRow1+"::"+newRow2)
+      // console.log("Rows Display update" + idRow1+"::"+idRow2)
+      // console.log("Rows Display update" + newRow1+"::"+newRow2)
       _sendDisplayData(1, newRow1, activeDevice, midiOutput)
       _sendDisplayData(0, newRow2, activeDevice, midiOutput)
     }
@@ -234,12 +235,18 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   var channelIndex = channelControl.instance
 
   channelControl.fader.mSurfaceValue.mOnTitleChange = (function (activeDevice, objectTitle, valueTitle) {
-    console.log("Fader Title Change: " + channelIndex + "::" + objectTitle + ":" + valueTitle)
+    // console.log("Fader Title Change: " + channelIndex + "::" + objectTitle + ":" + valueTitle)
     var activePage = activeDevice.getState("activePage")
     var faderTitles = activeDevice.getState(activePage + ' - Fader - Title')
     var faderValueTitles = activeDevice.getState(activePage + ' - Fader - ValueTitles')
 
     switch (activePage) {
+      case "Midi":
+        // MIDI Page is special since it uses a separate midi port and completely separate display and MIDI routing setup
+        // This update of the display is simply to ensure that should this event be received (which it is during init for example) then
+        // the Midi display state values won't be overwritten as they are handed by the custom onValueChange call in the page
+        Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+        break;
       case "ChannelStrip":
       case "SelectedTrack":
         activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(channelIndex, makeLabel(valueTitle, 6), faderValueTitles))
@@ -254,12 +261,19 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   }).bind({ midiOutput })
 
   channelControl.fader.mSurfaceValue.mOnDisplayValueChange = (function (activeDevice, value, units) {
-    // console.log("Fader Display Value Change: " + value + ":" + units)
     var activePage = activeDevice.getState("activePage")
     var faderValues = activeDevice.getState(activePage + ' - Fader - Values')
 
-    activeDevice.setState(activePage + ' - Fader - Values', setTextOfColumn(channelIndex, makeLabel(value, 6), faderValues))
-    Helper_updateDisplay('Row1', activePage + ' - Fader - Values', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
+    // console.log("Fader Display Value Change: " + value + ":" + activePage)
+
+    switch (activePage) {
+      case "Midi":
+        break;
+      default:
+        activeDevice.setState(activePage + ' - Fader - Values', setTextOfColumn(channelIndex, makeLabel(value, 6), faderValues))
+        Helper_updateDisplay('Row1', activePage + ' - Fader - Values', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
+        break;
+    }
 
   }).bind({ midiOutput, channelIndex })
 
@@ -271,6 +285,12 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
     var panValueTitles = activeDevice.getState(activePage + ' - Pan - ValueTitles')
 
     switch (activePage) {
+      case "Midi":
+        // MIDI Page is special since it uses a separate midi port and completely separate display and MIDI routing setup
+        // This update of the display is simply to ensure that should this event be received (which it is during init for example) then
+        // the Midi display state values won't be overwritten as they are handed by the custom onValueChange call in the page
+        Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+        break;
       case "SelectedTrack":
         switch (activeSubPage) {
           case "SendsQC":

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -80,77 +80,6 @@ function Helper_updateDisplay(/** @type {string} */idRow1, /** @type {string} */
 }
 
 
-// function updateDisplay(/** @type {MR_ActiveDevice} */activeDevice, /** @type {MR_DeviceMidiOutput} */midiOutput, /** @type {Object} */surfaceElements) {
-//   var activePage = activeDevice.getState("activePage")
-//   var activeSubPage = activeDevice.getState("activeSubPage")
-//   switch (activePage) {
-//     case "Mixer":
-//       for (var i = 0; i < surfaceElements.numStrips; ++i) {
-//         var element = surfaceElements.channelControls[i]
-//         if (!flip) {
-//           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 1, makeLabel(element.faderObjectTitle, 6)))
-//           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.faderValueTitle, 6)))
-//           midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
-//         }
-//         else {
-//           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 1, makeLabel(element.panObjectTitle, 6)))
-//           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.panValueTitle, 6)))
-//           midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
-//         }
-//       }
-//       break;
-//     case "SelectedTrack":
-//       var msg = surfaceElements.channelControls[0].trackObjectTitle
-//       if (!flip) {
-//         midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
-//         // For selected track all the trackObjectTitle are set to the same value
-//         // So send it once to the display and use the entire top line for the title
-//         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel('QC-' + msg, 56)))
-//         for (var i = 0; i < surfaceElements.numStrips; ++i) {
-//           var element = surfaceElements.channelControls[i]
-//           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.faderValueTitle, 6)))
-//         }
-//       }
-//       else {
-//         midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
-//         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("Sends-" + msg, 56)))
-//         for (var i = 0; i < surfaceElements.numStrips; ++i) {
-//           var element = surfaceElements.channelControls[i]
-//           if (element.panPushValue == "On") {
-//             midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.panObjectTitle, 6)))
-//           } else {
-//             midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel("Off", 6)))
-//           }
-//         }
-//       }
-//       break;
-//     default:
-//       console.log("No page specific binding defined")
-//       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No " + activePage + " specific binding defined", 56)))
-//       break;
-//   }
-
-//   // Update indicator characters - last char of each row
-//   function display_indicator(row, indicator) {
-//     var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-//     ]
-//     if (row === 0) {
-//       data.push(55)
-//     } else {
-//       data.push(111)
-//     }
-//     data.push(indicator.charCodeAt(0))
-//     data.push(0xf7)
-//     midiOutput.sendMidi(activeDevice, data)
-//   }
-
-//   var indicator1 = activeDevice.getState("indicator1")
-//   var indicator2 = activeDevice.getState("indicator2")
-
-//   display_indicator(1, indicator1)
-//   display_indicator(0, indicator2)
-// }
-
 /**
  * @param {MR_DeviceSurface} surface
  * @param {MR_DeviceMidiInput} midiInput
@@ -488,38 +417,6 @@ function makeTransport(surface, midiInput, midiOutput, x, y, surfaceElements) {
   //
   transport.btnZoomOnOff = surface.makeButton(x + 3.5, y + 15, 2, 2).setShapeCircle()
   bindMidiNote(transport.btnZoomOnOff, 0, 100)
-  // transport.zoomState = surface.makeCustomValueVariable('ZoomState');
-  // transport.zoomState.mMidiBinding.setInputPort(midiInput).bindToNote(0, 100)
-  // transport.zoomState.mOnProcessValueChange = function (activeDevice, number1, number2) {
-
-  //   console.log("zoomState: " + number1 + ":" + number2)
-  //   // switch (activePage) {
-  //   //   case "Mixer":
-  //   //     if (touched) {
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderValueTitle, 6)))
-  //   //     }
-  //   //     else {
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderObjectTitle, 6)))
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
-  //   //     }
-  //   //     break;
-  //   //   case "SelectedTrack":
-  //   //     if (touched) {
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.faderValueTitle, 56)))
-  //   //     }
-  //   //     else {
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.trackObjectTitle, 56)))
-  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
-  //   //     }
-  //   //     break;
-  //   //   default:
-  //   //     console.log("No page specific binding defined")
-  //   //     midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
-  //   //     break;
-  //   // }
-
-  // }
-
 
   // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
   // None - CC 60

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -43,7 +43,7 @@ function Helper_updateDisplay(/** @type {string} */idRow1, /** @type {string} */
   } else {
     // Update display if it has changed
     if ((newRow1 !== prevRow1) || (newRow2 !== prevRow2) || (activeDisplayType !== displayType)) {
-      // console.log("Rows Display update" + newRow1+"::"+newRow2)
+       console.log("Rows Display update" + newRow1+"::"+newRow2)
       _sendDisplayData(1, newRow1, activeDevice, midiOutput)
       _sendDisplayData(0, newRow2, activeDevice, midiOutput)
     }
@@ -241,9 +241,6 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
 
     switch (activePage) {
       case "ChannelStrip":
-        activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(channelIndex, makeLabel(valueTitle, 6), faderValueTitles))
-        Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
-        break;
       case "SelectedTrack":
         activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(channelIndex, makeLabel(valueTitle, 6), faderValueTitles))
         Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -157,19 +157,32 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
 
   // TITLE OF VALUE
   channelControl.fader.mSurfaceValue.mOnTitleChange = function (context, objectTitle, valueTitle) {
-    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeStringMax6CharectersAndRemoveSpace(valueTitle)))
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(valueTitle)))
   }
 
   channelControl.fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(value)))
   }
 
+  function makeLabel(value) {
 
-  function makeStringMax6CharectersAndRemoveSpace(value) {
-    //return value.length > 6 ? value.replace(/\s/g, '').slice(0, 6) : value
-    return value.replace(/\s/g, '').slice(0, 6)
+      var words = value.split(" ");
+      var label = "";
+
+      for(var i = 0 , len = words.length; i < len; i++) {
+
+        var currentStr = words[i];
+
+        var tempStr = currentStr
+
+        // convert first letter to upper case and remove all vowels after first letter
+        tempStr = tempStr.substr(0, 1).toUpperCase() + tempStr.substr(1).replace(/[aeiou]/gi, '');
+
+        label +=tempStr;
+
+      }
+      return label.slice(0, 6); // Remove vowels and shorten to 6 char label
   }
-  // ADDED BY JESPER ENDS
 
   return channelControl
 

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -1,4 +1,28 @@
 /**
+ * @param {MR_DeviceSurface} surface
+ * @param {String} name
+ * @param {number} note
+ * @param {Boolean} toggle
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ *
+ */
+ function makeLedButton(surface, note, x, y, w, h) {
+  var button = surface.makeButton(x, y, w, h)
+  button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, note)
+  button.mSurfaceValue.mOnProcessValueChange = (function (activeDevice, value) {
+  if (value > 0)
+    this.midiOutput.sendMidi(activeDevice, [0x90, note, 127])
+  else {
+    this.midiOutput.sendMidi(activeDevice, [0x90, note, 0])
+      }
+  }).bind({ midiOutput })
+  return button
+}
+
+/**
  * @constructor
  * @param {MR_DeviceSurface} surface
  * @param {MR_DeviceMidiInput} midiInput
@@ -21,15 +45,6 @@ function channelControl(surface, midiInput, midiOutput, x, y, instance) {
   this.ident = function () {
     return ("Class channelControl");
   }
-
-  this.vPotValue = 0;
-  this.vPotPushValue = 0;
-  this.vFaderValue = 0;
-  this.vFaderTouched = 0;
-  this.vSelLedOn = 0;
-  this.vMuteLedOn = 0;
-  this.vSoloLedOn = 0;
-  this.vRecLedOn = 0;
 
   // Pot encoder
   this.pushEncoder = this.surface.makePushEncoder(this.x, y, 2, 2)
@@ -56,37 +71,15 @@ function channelControl(surface, midiInput, midiOutput, x, y, instance) {
     .setInputPort(midiInput)
     .bindToNote(0, 104 + this.instance)
 
-  // Channel Buittons
-  this.sel_button = surface.makeButton(fader_x + 1, fader_y + 4, 1, 1)
-  this.sel_button.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .setOutputPort(midiOutput)
-    .bindToNote(0, 24 + this.instance)
+  // Channel Buttons
+  this.sel_button = makeLedButton(surface, 24 + this.instance, fader_x + 1, fader_y + 4, 1, 1)
+  this.mute_button = makeLedButton(surface, 16 + this.instance, fader_x + 1, fader_y + 5, 1, 1)
+  this.solo_button = makeLedButton(surface, 8 + this.instance, fader_x + 1, fader_y + 6, 1, 1)
+  this.sel_button = makeLedButton(surface, 0 + this.instance, fader_x + 1, fader_y + 7, 1, 1)
 
-  this.mute_button = surface.makeButton(fader_x + 1, fader_y + 5, 1, 1)
-  this.mute_button.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToNote(0, 16 + this.instance)
-
-  this.solo_button = surface.makeButton(fader_x + 1, fader_y + 6, 1, 1)
-  this.solo_button.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToNote(0, 8 + this.instance)
-
-  this.rec_button = surface.makeButton(fader_x + 1, fader_y + 7, 1, 1)
-  this.rec_button.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToNote(0, 0 + this.instance)
 }
 
-// channelControl.prototype.setSelLedOn = function (value) {
-//   this.vSelLedOn = value;
-// }
-
-// channelControl.prototype.sendSelLed = function (context) {
-//   this.midiOutput.sendMidi(context, [0x90, this.instance + 24, this.vSelLedOn]);
-// }
-
 module.exports = {
-  channelControl
+  channelControl,
+  makeLedButton
 }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -120,12 +120,12 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.surface = surface;
   channelControl.midiInput = midiInput;
   channelControl.midiOutput = midiOutput;
-  channelControl.x = x + 2 * instance;
+  channelControl.x = x + 7 * instance;
   channelControl.y = y;
   channelControl.instance = instance; // Channel number, 1-8
 
   // Pot encoder
-  channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y, 2, 2)
+  channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y+2, 4, 4)
 
   channelControl.pushEncoder.mEncoderValue.mMidiBinding
     .setInputPort(midiInput)
@@ -138,50 +138,56 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
 
   // Fader + Fader Touch
   var fader_x = channelControl.x
-  var fader_y = y + 3
-  var tf = makeTouchFader(surface, midiInput, channelControl.midiOutput, instance, fader_x, fader_y, 1, 8)
+  var fader_y = y + 7
+  var tf = makeTouchFader(surface, midiInput, channelControl.midiOutput, instance, fader_x, fader_y, 3, 18)
   channelControl.fader = tf[0]
   channelControl.fader_touch = tf[1]
 
   // Channel Buttons
-  channelControl.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + channelControl.instance, fader_x + 1, fader_y + 4, 1, 1, false)
-  channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 1, fader_y + 5, 1, 1, false)
-  channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 1, fader_y + 6, 1, 1, false)
-  channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 1, fader_y + 7, 1, 1, true)
+  channelControl.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + channelControl.instance, fader_x + 4, fader_y + 6, 3, 3, false)
+  channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 4, fader_y + 9, 3, 3, false)
+  channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 4, fader_y + 12, 3, 3, false)
+  channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 4, fader_y + 15, 3, 3, true)
 
-  // ADDED BY JESPER START
   var channelIndex = channelControl.instance
 
-  //0xF0 0x00 0x00 0x66 0x14 0x12 ' + pos + ' ' + text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^\x00-\x7F]/g, "?").split('').map(x => x.charCodeAt(0)).join(' ') + ' 0xF7
-
-
-  // TITLE OF VALUE
   channelControl.fader.mSurfaceValue.mOnTitleChange = function (context, objectTitle, valueTitle) {
-    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(valueTitle)))
+    console.log(objectTitle)
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(objectTitle)))
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(valueTitle)))
   }
 
   channelControl.fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
     midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(value)))
   }
 
+  // channelControl.fader.mSurfaceValue.mOnProcessValueChange  = function (context, newValue, oldValue) {
+  //   // midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, newValue))
+  // }
+
   function makeLabel(value) {
+    // Do nothing if the label is already short enough
+    if (value.length <= 6) {
+      return value
+    }
 
-      var words = value.split(" ");
-      var label = "";
+    // If to long shorten it by removing vowels and making it CamelCase to remove spaces
+    var words = value.split(" ");
+    var label = "";
 
-      for(var i = 0 , len = words.length; i < len; i++) {
+    for(var i = 0 , len = words.length; i < len; i++) {
 
-        var currentStr = words[i];
+      var currentStr = words[i];
 
-        var tempStr = currentStr
+      var tempStr = currentStr
 
-        // convert first letter to upper case and remove all vowels after first letter
-        tempStr = tempStr.substr(0, 1).toUpperCase() + tempStr.substr(1).replace(/[aeiou]/gi, '');
+      // convert first letter to upper case and remove all vowels after first letter
+      tempStr = tempStr.substr(0, 1).toUpperCase() + tempStr.substr(1).replace(/[aeiou]/gi, '');
 
-        label +=tempStr;
+      label +=tempStr;
 
-      }
-      return label.slice(0, 6); // Remove vowels and shorten to 6 char label
+    }
+    return label.slice(0, 6); // Remove vowels and shorten to 6 char label
   }
 
   return channelControl
@@ -203,7 +209,7 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   masterControl.surface = surface;
   masterControl.midiInput = midiInput;
   masterControl.midiOutput = midiOutput;
-  masterControl.x = x + 2 * instance;
+  masterControl.x = x + 7 * instance;
   masterControl.y = y;
   masterControl.instance = instance; // 9 - Master
 
@@ -214,14 +220,14 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   // Fader + Fader Touch
   var fader_x = masterControl.x
   var fader_y = y + 3
-  var tf = makeTouchFader(surface, midiInput, midiOutput, instance, fader_x, fader_y, 1, 8)
+  var tf = makeTouchFader(surface, midiInput, midiOutput, instance, fader_x, fader_y, 3, 18)
   masterControl.fader = tf[0]
   masterControl.fader_touch = tf[1]
 
   // Channel Buttons
-  masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1, false)
-  masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1, false)
-  masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1, false)
+  masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 3, fader_y + 6, 3, 3, false)
+  masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 3, fader_y + 9, 3, 3, false)
+  masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 3, fader_y + 12, 3, 3, false)
 
   return masterControl
 }
@@ -234,8 +240,8 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   transport.x = x;
   transport.y = y;
 
-  var w = 1
-  var h = 1
+  var w = 3
+  var h = 3
 
   transport.ident = function () {
     return ("Class Transport");
@@ -246,31 +252,31 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   }
 
   transport.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h, false)
-  transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h, false)
+  transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 3, y, w, h, false)
 
-  transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h, false)
-  transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h, false)
+  transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 3, w, h, false)
+  transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 3, y + 3, w, h, false)
 
-  transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h, false)
-  transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h, false)
+  transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 6, w, h, false)
+  transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 3, y + 6, w, h, false)
 
-  transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h, false)
-  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h, false)
+  transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 3, y + 9, w, h, false)
+  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 9, w, h, false)
 
-  transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h, false)
-  transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h, false)
+  transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 12, w, h, false)
+  transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 3, y + 12, w, h, false)
 
   // The Note on/off events for the special functioans are timestamped at the same time
   // cubase midi remote doesn't show anything on screen though a note is sent
   // Flip - Simultaneous press of Pre Chn+Pre Bank
-  transport.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
+  transport.btnFlip = surface.makeButton(x+0.5, y + 15, 2, 2).setShapeCircle()
   bindMidiNote(transport.btnFlip, 0, 50)
 
   // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
   // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
   // If zoom is active and you simply press then other button the event will not be sent
   //
-  transport.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
+  transport.btnZoomOnOff = surface.makeButton(x + 3.5, y + 15, 2, 2).setShapeCircle()
   bindMidiNote(transport.btnZoomOnOff, 0, 100)
 
   // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
@@ -285,7 +291,7 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   // ? One weird side effect of this is the Knob displayed in Cubase will show its "value" in a weird way.
   // todo I wonder if there is a way to change that behaviour?
 
-  transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
+  transport.jog_wheel = surface.makePushEncoder(x, y + 17, 6, 6)
   transport.jog_wheel.mEncoderValue.mMidiBinding
     .setInputPort(midiInput)
     .setIsConsuming(true)
@@ -301,15 +307,15 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   bindCommandKnob(transport.jog_wheel.mEncoderValue, transport.jogRightVariable, transport.jogLeftVariable);
 
   //Zoom Vertical
-  transport.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
+  transport.zoomVertOut = surface.makeButton(x + 9, y + 8, 2, 2).setShapeCircle()
   bindMidiNote(transport.zoomVertOut, 0, 96)
-  transport.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
+  transport.zoomVertIn = surface.makeButton(x + 11, y + 8, 2, 2).setShapeCircle()
   bindMidiNote(transport.zoomVertIn, 0, 97)
 
   //Zoom Horizontal
-  transport.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
+  transport.zoomHorizOut = surface.makeButton(x + 9, y + 10, 2, 2).setShapeCircle()
   bindMidiNote(transport.zoomHorizOut, 0, 98)
-  transport.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
+  transport.zoomHorizIn = surface.makeButton(x + 11, y + 10, 2, 2).setShapeCircle()
   bindMidiNote(transport.zoomHorizIn, 0, 99)
 
   return transport

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -253,7 +253,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   }).bind({ midiOutput })
 
   channelControl.fader.mSurfaceValue.mOnDisplayValueChange = (function (activeDevice, value, units) {
-    console.log("Fader Display Value Change: " + value + ":" + units)
+    // console.log("Fader Display Value Change: " + value + ":" + units)
     var activePage = activeDevice.getState("activePage")
     var faderValues = activeDevice.getState(activePage + ' - Fader - Values')
 
@@ -263,7 +263,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   }).bind({ midiOutput, channelIndex })
 
   channelControl.pushEncoder.mEncoderValue.mOnTitleChange = (function (activeDevice, objectTitle, valueTitle) {
-    console.log("Pan Title Changed:" + objectTitle + ":" + valueTitle)
+    // console.log("Pan Title Changed:" + objectTitle + ":" + valueTitle)
     var activePage = activeDevice.getState("activePage")
     var panTitles = activeDevice.getState(activePage + ' - Pan - Title')
     var panValueTitles = activeDevice.getState(activePage + ' - Pan - ValueTitles')
@@ -287,7 +287,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   }).bind({ midiOutput, channelIndex })
 
   channelControl.pushEncoder.mEncoderValue.mOnDisplayValueChange = (function (activeDevice, value, units) {
-    console.log("Pan Value Change: " + value + ":" + units)
+    // console.log("Pan Value Change: " + value + ":" + units)
     var activePage = activeDevice.getState("activePage")
     var panValues = activeDevice.getState(activePage + ' - Pan - Values')
 

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -116,7 +116,7 @@ function makeLedButton(surface, midiInput, midiOutput, note, x, y, w, h, circle)
 }
 
 function clearAllLeds(/** @type {MR_ActiveDevice} */activeDevice, /** @type {MR_DeviceMidiOutput} */midiOutput) {
-  console.log('Clear All Leds')
+  // console.log('Clear All Leds')
   // Mixer buttons
   for (var i = 0; i < 8; ++i) {
     midiOutput.sendMidi(activeDevice, [0x90, 24 + i, 0])

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -23,6 +23,31 @@
 }
 
 /**
+ * @param {MR_DeviceSurface} surface
+ * @param {MR_DeviceMidiInput} midiInput
+ * @param {Number} channel    - instance of the push encoder.
+ * @param {number} x           - x location of the push encoder in the gui
+ * @param {Number} y           - y location of the push encoder in the gui
+ * @param {Number} w           - width of the push encoder.
+ * @param {Number} h           - height of the push encoder.
+ */
+function makeTouchFader(surface, midiInput, midiOutput, channel, x, y, w, h) {
+  // Fader + Fader Touch
+  var fader = surface.makeFader(x, y, w, h).setTypeVertical()
+  fader.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToPitchBend(channel)
+
+  var fader_touch = surface.makeButton(x + 1, y, 1, 1)
+  fader_touch.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 104 + channel)
+
+  return [fader,fader_touch]
+}
+
+/**
  * @constructor
  * @param {MR_DeviceSurface} surface
  * @param {MR_DeviceMidiInput} midiInput
@@ -61,25 +86,58 @@ function channelControl(surface, midiInput, midiOutput, x, y, instance) {
   // Fader + Fader Touch
   var fader_x = this.x
   var fader_y = y + 3
-  this.fader = surface.makeFader(fader_x, fader_y, 1, 8).setTypeVertical()
-  this.fader.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToPitchBend(this.instance)
-
-  this.fader_touch = surface.makeButton(fader_x + 1, fader_y, 1, 1)
-  this.fader_touch.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToNote(0, 104 + this.instance)
+  var tf = makeTouchFader(surface, midiInput, this.midiOutput, instance, fader_x, fader_y, 1, 8)
+  this.fader = tf[0]
+  this.fader_touch = tf[1]
 
   // Channel Buttons
   this.sel_button = makeLedButton(surface, 24 + this.instance, fader_x + 1, fader_y + 4, 1, 1)
   this.mute_button = makeLedButton(surface, 16 + this.instance, fader_x + 1, fader_y + 5, 1, 1)
   this.solo_button = makeLedButton(surface, 8 + this.instance, fader_x + 1, fader_y + 6, 1, 1)
-  this.sel_button = makeLedButton(surface, 0 + this.instance, fader_x + 1, fader_y + 7, 1, 1)
+  this.rec_button = makeLedButton(surface, 0 + this.instance, fader_x + 1, fader_y + 7, 1, 1)
+
+}
+
+/**
+ * @param {MR_DeviceSurface} surface
+ * @param {MR_DeviceMidiInput} midiInput
+ * @param {MR_DeviceMidiOutput} midiOutput
+ * @param {number} x           - x location of the push encoder in the gui
+ * @param {Number} y           - y location of the push encoder in the gui
+ * @param {Number} w           - width of the push encoder.
+ * @param {Number} h           - height of the push encoder.
+ * @param {Number} instance    - instance of the push encoder.
+ */
+ function masterControl(surface, midiInput, midiOutput, x, y, instance) {
+  // Position on GUI
+  this.surface = surface;
+  this.midiInput = midiInput;
+  this.midiOutput = midiOutput;
+  this.x = x + 2 * instance;
+  this.y = y;
+  this.instance = instance; // 9 - Master
+
+  this.ident = function () {
+    return ("Class masterControl");
+  }
+
+  // Fader + Fader Touch
+  var fader_x = this.x
+  var fader_y = y + 3
+  var tf = makeTouchFader(surface, midiInput, midiOutput, instance, fader_x, fader_y, 1, 8)
+  this.fader = tf[0]
+  this.fader_touch = tf[1]
+
+  // Channel Buttons
+  this.mixer_button = makeLedButton(surface, 84, fader_x + 1, fader_y + 4, 1, 1)
+  this.read_button = makeLedButton(surface, 74, fader_x + 1, fader_y + 5, 1, 1)
+  this.write_button = makeLedButton(surface, 75, fader_x + 1, fader_y + 6, 1, 1)
 
 }
 
 module.exports = {
   channelControl,
-  makeLedButton
+  masterControl,
+  makeLedButton,
+  makeTouchFader
 }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -3,6 +3,11 @@ var makeLabel = helper.display.makeLabel
 var flip = false
 
 function updateDisplay(activeDevice) {
+  if(flip) {
+    midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
+  } else {
+    midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
+  }
   switch (activePage) {
     case "Mixer":
       for (var i = 0; i < surfaceElements.numStrips; ++i) {
@@ -86,7 +91,7 @@ function clearAllLeds(activeDevice, midiOutput) {
     midiOutput.sendMidi(activeDevice, [0x90, 0 + i, 0])
   }
   // Master Fader buttons
-  midiOutput.sendMidi(activeDevice, [0x90, 84, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
   midiOutput.sendMidi(activeDevice, [0x90, 74, 0])
   midiOutput.sendMidi(activeDevice, [0x90, 75, 0])
 
@@ -338,7 +343,6 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   masterControl.x = x + 7 * instance;
   masterControl.y = y;
   masterControl.instance = instance; // 9 - Master
-
   masterControl.ident = function () {
     return ("Class masterControl");
   }
@@ -354,7 +358,18 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 3, fader_y + 6, 3, 3, false)
   masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 3, fader_y + 9, 3, 3, false)
   masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 3, fader_y + 12, 3, 3, false)
-
+  masterControl.mixer_button.mSurfaceValue.mOnProcessValueChange = function (activeDevice) {
+    var value = masterControl.mixer_button.mSurfaceValue.getProcessValue(activeDevice)
+    if (value == 1) {
+      flip = !flip
+      if (flip)
+        midiOutput.sendMidi(activeDevice, [0x90, 84, 127])
+      else {
+        midiOutput.sendMidi(activeDevice, [0x90, 84, 0])
+      }
+      updateDisplay(activeDevice)
+    }
+  }
   return masterControl
 }
 

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -7,11 +7,14 @@
  * @param {number} y
  * @param {number} w
  * @param {number} h
- *
+ * @param {boolean} circle
  */
-function makeLedButton(surface, midiInput, midiOutput, note, x, y, w, h) {
+function makeLedButton(surface, midiInput, midiOutput, note, x, y, w, h, circle) {
   var button = surface.makeButton(x, y, w, h)
   button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, note)
+  if (circle) {
+    button.setShapeCircle()
+  }
   button.mSurfaceValue.mOnProcessValueChange = function (activeDevice) {
     if (button.mSurfaceValue.getProcessValue(activeDevice) > 0)
       midiOutput.sendMidi(activeDevice, [0x90, note, 127])
@@ -111,10 +114,10 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.fader_touch = tf[1]
 
   // Channel Buttons
-  channelControl.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + channelControl.instance, fader_x + 1, fader_y + 4, 1, 1)
-  channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 1, fader_y + 5, 1, 1)
-  channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 1, fader_y + 6, 1, 1)
-  channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 1, fader_y + 7, 1, 1)
+  channelControl.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + channelControl.instance, fader_x + 1, fader_y + 4, 1, 1, false)
+  channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 1, fader_y + 5, 1, 1, false)
+  channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 1, fader_y + 6, 1, 1, false)
+  channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 1, fader_y + 7, 1, 1, true)
 
   return channelControl
 
@@ -151,9 +154,9 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   masterControl.fader_touch = tf[1]
 
   // Channel Buttons
-  masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1)
-  masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1)
-  masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1)
+  masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1, false)
+  masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1, false)
+  masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1, false)
 
   return masterControl
 }
@@ -177,20 +180,20 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
     button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(chn, num)
   }
 
-  transport.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h)
-  transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h)
+  transport.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h, false)
+  transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h, false)
 
-  transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h)
-  transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h)
+  transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h, false)
+  transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h, false)
 
-  transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h)
-  transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h)
+  transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h, false)
+  transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h, false)
 
-  transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h)
-  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h)
+  transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h, false)
+  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h, false)
 
-  transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h)
-  transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h)
+  transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h, false)
+  transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h, false)
 
   // The Note on/off events for the special functioans are timestamped at the same time
   // cubase midi remote doesn't show anything on screen though a note is sent

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -258,7 +258,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
     var faderValues = activeDevice.getState(activePage + ' - Fader - Values')
 
     activeDevice.setState(activePage + ' - Fader - Values', setTextOfColumn(channelIndex, makeLabel(value, 6), faderValues))
-    Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
+    Helper_updateDisplay('Row1', activePage + ' - Fader - Values', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
 
   }).bind({ midiOutput, channelIndex })
 
@@ -292,14 +292,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
     var panValues = activeDevice.getState(activePage + ' - Pan - Values')
 
     activeDevice.setState(activePage + ' - Pan - Values', setTextOfColumn(channelIndex, makeLabel(value, 6), panValues))
-    switch (activePage) {
-      case "SelectedTrack":
-        Helper_updateDisplay('Row1', 'Row2', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
-        break;
-      default:
-        Helper_updateDisplay('Row1', 'Row2', activePage + ' - Pan - Title', activePage + ' - Pan - Values', activeDevice, midiOutput)
-        break;
-    }
+    Helper_updateDisplay('Row1', 'Row2', 'AltRow1', activePage + ' - Pan - Values', activeDevice, midiOutput)
 
   }).bind({ midiOutput, channelIndex })
 

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -299,7 +299,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(value, 6)))
         break;
       case "SelectedTrack":
-        midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel('Sends-'+channelControl.trackObjectTitle +"-" +channelControl.panObjectTitle, 56)))
+        midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel('Sends-' + channelControl.trackObjectTitle + "-" + channelControl.panObjectTitle, 56)))
         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(value, 6)))
         break;
       default:

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -95,12 +95,12 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y, 2, 2)
 
   channelControl.pushEncoder.mEncoderValue.mMidiBinding
-    .setInputPort(midiInput).setOutputPort(midiOutput)
+    .setInputPort(midiInput)
     .bindToControlChange(0, 16 + channelControl.instance)
     .setTypeRelativeSignedBit()
 
   channelControl.pushEncoder.mPushValue.mMidiBinding
-    .setInputPort(midiInput).setOutputPort(midiOutput)
+    .setInputPort(midiInput)
     .bindToNote(0, 32 + channelControl.instance);
 
   // Fader + Fader Touch
@@ -186,8 +186,8 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h)
   transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h)
 
-  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h)
   transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h)
+  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h)
 
   transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h)
   transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h)
@@ -220,6 +220,7 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
   transport.jog_wheel.mEncoderValue.mMidiBinding
     .setInputPort(midiInput)
+    .setIsConsuming(true)
     .bindToControlChange(0, 60)
     .setTypeAbsolute()
   transport.jog_wheel.mPushValue.mMidiBinding

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -168,9 +168,9 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
   var channelIndex = channelControl.instance
 
   channelControl.fader_touch.mSurfaceValue.mOnProcessValueChange = function (context, touched, value2) {
+    channelControl.faderTouched = touched
     switch (activePage) {
       case "Mixer":
-        channelControl.faderTouched = touched
         if (touched) {
           midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderValueTitle, 6)))
         }
@@ -180,9 +180,8 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         }
         break;
       case "SelectedTrack":
-        channelControl.faderTouched = touched
         if (touched) {
-          midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderValueTitle, 6)))
+          midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.faderValueTitle, 56)))
         }
         else {
           midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.trackObjectTitle, 56)))
@@ -191,13 +190,13 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         break;
       default:
         console.error("No page specific binding defined")
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel(activePage, 56)))
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
         break;
     }
   }
 
   channelControl.trackNameDisplay.mOnTitleChange = function (context, objectTitle, valueTitle) {
-    console.log("Track Title Changed:"+objectTitle)
+    // console.log("Track Title Changed:"+objectTitle)
     channelControl.trackObjectTitle = objectTitle
     channelControl.trackValueTitle = valueTitle
     switch (activePage) {
@@ -211,7 +210,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         break;
       default:
         console.error("No page specific binding defined")
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel(activePage, 56)))
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
         break;
     }
   }
@@ -230,7 +229,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         break;
       default:
         console.error("No page specific binding defined")
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel(activePage, 56)))
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
         break;
     }
   }
@@ -245,7 +244,7 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
         break;
       default:
         console.error("No page specific binding defined")
-        // midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(0, makeLabel(activePage, 56)))
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
         break;
     }
   }
@@ -339,7 +338,7 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 12, w, h, false)
   transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 3, y + 12, w, h, false)
 
-  // The Note on/off events for the special functioans are timestamped at the same time
+  // The Note on/off events for the special functions are timestamped at the same time
   // cubase midi remote doesn't show anything on screen though a note is sent
   // Flip - Simultaneous press of Pre Chn+Pre Bank
   transport.btnFlip = surface.makeButton(x + 0.5, y + 15, 2, 2).setShapeCircle()

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -1,3 +1,4 @@
+var helper = require('./helper')
 /**
  * @param {MR_DeviceSurface} surface
  * @param {String} name
@@ -50,6 +51,8 @@ function clearAllLeds(activeDevice, midiOutput) {
   midiOutput.sendMidi(activeDevice, [0x90, 94, 0])
   midiOutput.sendMidi(activeDevice, [0x90, 95, 0])
   midiOutput.sendMidi(activeDevice, [0x90, 86, 0])
+
+  helper.display.reset(activeDevice, midiOutput)
 }
 
 /**
@@ -145,6 +148,28 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 1, fader_y + 5, 1, 1, false)
   channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 1, fader_y + 6, 1, 1, false)
   channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 1, fader_y + 7, 1, 1, true)
+
+  // ADDED BY JESPER START
+  var channelIndex = channelControl.instance
+
+  //0xF0 0x00 0x00 0x66 0x14 0x12 ' + pos + ' ' + text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^\x00-\x7F]/g, "?").split('').map(x => x.charCodeAt(0)).join(' ') + ' 0xF7
+
+
+  // TITLE OF VALUE
+  channelControl.fader.mSurfaceValue.mOnTitleChange = function (context, objectTitle, valueTitle) {
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeStringMax6CharectersAndRemoveSpace(valueTitle)))
+  }
+
+  channelControl.fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+  }
+
+
+  function makeStringMax6CharectersAndRemoveSpace(value) {
+    //return value.length > 6 ? value.replace(/\s/g, '').slice(0, 6) : value
+    return value.replace(/\s/g, '').slice(0, 6)
+  }
+  // ADDED BY JESPER ENDS
 
   return channelControl
 

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -124,6 +124,13 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.y = y;
   channelControl.instance = instance; // Channel number, 1-8
 
+  // Channel Displays
+  channelControl.displayTop = channelControl.surface.makeLabelField(channelControl.x,1,7,2)
+  channelControl.displayBottom =  channelControl.surface.makeLabelField(channelControl.x,3,7,2)
+
+  channelControl.faderValueDisplay  = channelControl.surface.makeCustomValueVariable('faderValueDisplay');
+  channelControl.panValueDisplay  = channelControl.surface.makeCustomValueVariable('panValueDisplay');
+
   // Pot encoder
   channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y+2, 4, 4)
 
@@ -151,18 +158,26 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
 
   var channelIndex = channelControl.instance
 
-  channelControl.fader.mSurfaceValue.mOnTitleChange = function (context, objectTitle, valueTitle) {
-    console.log(objectTitle)
+  // channelControl.fader.mSurfaceValue.mOnTitleChange = function (context, objectTitle, valueTitle) {
+  //   midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(objectTitle)))
+  //   midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(valueTitle)))
+  // }
+
+  channelControl.faderValueDisplay.mOnTitleChange = function (context, objectTitle, valueTitle) {
     midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(objectTitle)))
     midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(valueTitle)))
   }
 
-  channelControl.fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(value)))
+  channelControl.faderValueDisplay.mOnDisplayValueChange = function (context, value, units) {
+    midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, "|"+makeLabel(value)))
   }
+  // channelControl.panValueDisplay.mOnTitleChange = function (context, objectTitle, valueTitle) {
+  //   midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(objectTitle)))
+  //   midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(valueTitle)))
+  // }
 
-  // channelControl.fader.mSurfaceValue.mOnProcessValueChange  = function (context, newValue, oldValue) {
-  //   // midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, newValue))
+  // channelControl.panValueDisplay.mOnDisplayValueChange = function (context, value, units) {
+  //   midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(channelIndex, 0, "_"+makeLabel(value)))
   // }
 
   function makeLabel(value) {

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -234,12 +234,16 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   var channelIndex = channelControl.instance
 
   channelControl.fader.mSurfaceValue.mOnTitleChange = (function (activeDevice, objectTitle, valueTitle) {
-    // console.log("Fader Title Change: " + channelIndex + "::" + objectTitle + ":" + valueTitle)
+    console.log("Fader Title Change: " + channelIndex + "::" + objectTitle + ":" + valueTitle)
     var activePage = activeDevice.getState("activePage")
     var faderTitles = activeDevice.getState(activePage + ' - Fader - Title')
     var faderValueTitles = activeDevice.getState(activePage + ' - Fader - ValueTitles')
 
     switch (activePage) {
+      case "ChannelStrip":
+        activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(channelIndex, makeLabel(valueTitle, 6), faderValueTitles))
+        Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+        break;
       case "SelectedTrack":
         activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(channelIndex, makeLabel(valueTitle, 6), faderValueTitles))
         Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -45,7 +45,7 @@ function updateDisplay(activeDevice) {
       }
       break;
     default:
-      console.error("No page specific binding defined")
+      console.log("No page specific binding defined")
       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No " + activePage + " specific binding defined", 56)))
       break;
   }
@@ -448,7 +448,7 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
     //     }
     //     break;
     //   default:
-    //     console.error("No page specific binding defined")
+    //     console.log("No page specific binding defined")
     //     midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
     //     break;
     // }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -25,6 +25,33 @@ function makeLedButton(surface, midiInput, midiOutput, note, x, y, w, h, circle)
   return button
 }
 
+function clearAllLeds(activeDevice, midiOutput) {
+  console.log('Clear All Leds')
+  // Mixer buttons
+  for (var i = 0; i < 8; ++i) {
+    midiOutput.sendMidi(activeDevice, [0x90, 24 + i, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 16 + i, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 8 + i, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 0 + i, 0])
+  }
+  // Master Fader buttons
+  midiOutput.sendMidi(activeDevice, [0x90, 84, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 74, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 75, 0])
+
+  // Transport Buttons
+  midiOutput.sendMidi(activeDevice, [0x90, 48, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 49, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 46, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 47, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 91, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 92, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 93, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 94, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 95, 0])
+  midiOutput.sendMidi(activeDevice, [0x90, 86, 0])
+}
+
 /**
  * @param {MR_DeviceSurface} surface
  * @param {MR_DeviceMidiInput} midiInput
@@ -256,5 +283,6 @@ module.exports = {
   makeTransport,
   makeLedButton,
   makeTouchFader,
-  bindCommandKnob
+  bindCommandKnob,
+  clearAllLeds
 }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -422,38 +422,38 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   // If zoom is active and you simply press then other button the event will not be sent
   //
   transport.btnZoomOnOff = surface.makeButton(x + 3.5, y + 15, 2, 2).setShapeCircle()
-  // bindMidiNote(transport.btnZoomOnOff, 0, 100)
-  transport.zoomState = surface.makeCustomValueVariable('ZoomState');
-  transport.zoomState.mMidiBinding.setInputPort(midiInput).bindToNote(0, 100)
-  transport.zoomState.mOnProcessValueChange = function (activeDevice, number1, number2) {
+  bindMidiNote(transport.btnZoomOnOff, 0, 100)
+  // transport.zoomState = surface.makeCustomValueVariable('ZoomState');
+  // transport.zoomState.mMidiBinding.setInputPort(midiInput).bindToNote(0, 100)
+  // transport.zoomState.mOnProcessValueChange = function (activeDevice, number1, number2) {
 
-    console.log("zoomState: " + number1 + ":" + number2)
-    // switch (activePage) {
-    //   case "Mixer":
-    //     if (touched) {
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderValueTitle, 6)))
-    //     }
-    //     else {
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderObjectTitle, 6)))
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
-    //     }
-    //     break;
-    //   case "SelectedTrack":
-    //     if (touched) {
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.faderValueTitle, 56)))
-    //     }
-    //     else {
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.trackObjectTitle, 56)))
-    //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
-    //     }
-    //     break;
-    //   default:
-    //     console.log("No page specific binding defined")
-    //     midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
-    //     break;
-    // }
+  //   console.log("zoomState: " + number1 + ":" + number2)
+  //   // switch (activePage) {
+  //   //   case "Mixer":
+  //   //     if (touched) {
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderValueTitle, 6)))
+  //   //     }
+  //   //     else {
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 1, makeLabel(channelControl.faderObjectTitle, 6)))
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
+  //   //     }
+  //   //     break;
+  //   //   case "SelectedTrack":
+  //   //     if (touched) {
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.faderValueTitle, 56)))
+  //   //     }
+  //   //     else {
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel(channelControl.trackObjectTitle, 56)))
+  //   //       midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(channelIndex, 0, makeLabel(channelControl.faderValueTitle, 6)))
+  //   //     }
+  //   //     break;
+  //   //   default:
+  //   //     console.log("No page specific binding defined")
+  //   //     midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("No "+activePage+" specific binding defined", 56)))
+  //   //     break;
+  //   // }
 
-  }
+  // }
 
 
   // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -141,13 +141,13 @@ function repeatCommand(activeDevice, command, repeats) {
   }
 }
 /**
- * @param {MR_PushEncoder} pushEncoder
+ * @param {MR_SurfaceElementValue} pushEncoder
  * @param {MR_SurfaceCustomValueVariable} commandIncrease
  * @param {MR_SurfaceCustomValueVariable} commandDecrease
  */
  function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   // console.log('from script: createCommandKnob')
-  pushEncoder.mEncoderValue.mOnProcessValueChange = function (activeDevice, value) {
+  pushEncoder.mOnProcessValueChange = function (activeDevice, value) {
       console.log('value changed: ' + value)
       if (value < 0.5) {
           var jump_rate = Math.floor(value * 127)
@@ -159,45 +159,54 @@ function repeatCommand(activeDevice, command, repeats) {
   }
 }
 
-function makeTransport(surface, x, y) {
-  var transport = {}
+function Transport(surface, midiInput, midiOutput, x, y) {
+  this.surface = surface;
+  this.midiInput = midiInput;
+  this.midiOutput = midiOutput;
+  this.x = x;
+  this.y = y;
+
   var w = 1
   var h = 1
+
+  this.ident = function () {
+    return ("Class Transport");
+  }
 
   function bindMidiNote(button, chn, num) {
       button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(chn, num)
   }
 
-  transport.prevChn = makeLedButton(surface, 48,  x, y, w, h)
-  transport.nextChn = makeLedButton(surface, 49,  x + 1, y, w, h)
+  this.prevChn = makeLedButton(surface, 48,  x, y, w, h)
+  this.nextChn = makeLedButton(surface, 49,  x + 1, y, w, h)
 
   // TODO Not implemented yet - not sure what to use them for
   // TODO Perhaps Change the Page in the midi remote??
-  transport.prevBnk = makeLedButton(surface, 46, x, y + 1, w, h)
+  this.prevBnk = makeLedButton(surface, 46, x, y + 1, w, h)
   // TODO Not implemented yet - not sure what to use them for
-  transport.nextBnk = makeLedButton(surface, 47, x + 1, y + 1, w, h)
+  this.nextBnk = makeLedButton(surface, 47, x + 1, y + 1, w, h)
 
-  transport.btnRewind = makeLedButton(surface, 91, x, y + 2, w, h)
-  transport.btnForward = makeLedButton(surface, 92, x + 1, y + 2, w, h)
+  this.btnRewind = makeLedButton(surface, 91, x, y + 2, w, h)
+  this.btnForward = makeLedButton(surface, 92, x + 1, y + 2, w, h)
 
-  transport.btnStart = makeLedButton(surface, 94, x, y + 3, w, h)
-  transport.btnStop = makeLedButton(surface, 93, x + 1, y + 3, w, h)
+  this.btnStart = makeLedButton(surface, 94, x, y + 3, w, h)
+  this.btnStop = makeLedButton(surface, 93, x + 1, y + 3, w, h)
 
-  transport.btnRecord = makeLedButton(surface, 95, x, y + 4, w, h)
-  transport.btnCycle = makeLedButton(surface, 86, x + 1, y + 4, w, h)
+  this.btnRecord = makeLedButton(surface, 95, x, y + 4, w, h)
+  this.btnCycle = makeLedButton(surface, 86, x + 1, y + 4, w, h)
 
   // The Note on/off events for the special functioans are timestamped at the same time
   // cubase midi remote doesn't show anything on screen though a note is sent
   // Flip - Simultaneous press of Pre Chn+Pre Bank
-  transport.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
-  bindMidiNote(transport.btnFlip, 0, 50)
+  this.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
+  bindMidiNote(this.btnFlip, 0, 50)
 
   // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
   // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
   // If zoom is active and you simply press then other button the event will not be sent
   //
-  transport.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
-  bindMidiNote(transport.btnZoomOnOff, 0, 100)
+  this.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
+  bindMidiNote(this.btnZoomOnOff, 0, 100)
 
   // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
   // None - CC 60
@@ -211,28 +220,31 @@ function makeTransport(surface, x, y) {
   // ? One weird side effect of this is the Knob displayed in Cubase will show its "value" in a weird way.
   // todo I wonder if there is a way to change that behaviour?
 
-  transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
-  transport.jog_wheel.mEncoderValue.mMidiBinding
+  this.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
+  this.jog_wheel.mEncoderValue.mMidiBinding
       .setInputPort(midiInput)
       .bindToControlChange(0, 60)
       .setTypeAbsolute()
-  transport.jog_wheel.mPushValue.mMidiBinding
+  this.jog_wheel.mPushValue.mMidiBinding
       .setInputPort(midiInput)
       .bindToNote(0, 101)
+   // ? This is still passing midi events through. It's unclear how to stop the midi CC messages passing through other then removing the MIDI port from All In
+   this.jogLeftVariable = surface.makeCustomValueVariable('jogLeft')
+   this.jogRightVariable = surface.makeCustomValueVariable('jogRight')
+
+   bindCommandKnob(this.jog_wheel.mEncoderValue, this.jogRightVariable, this.jogLeftVariable);
 
   //Zoom Vertical
-  transport.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
-  bindMidiNote(transport.zoomVertOut, 0, 96)
-  transport.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
-  bindMidiNote(transport.zoomVertIn, 0, 97)
+  this.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(this.zoomVertOut, 0, 96)
+  this.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(this.zoomVertIn, 0, 97)
 
   //Zoom Horizontal
-  transport.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
-  bindMidiNote(transport.zoomHorizOut, 0, 98)
-  transport.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
-  bindMidiNote(transport.zoomHorizIn, 0, 99)
-
-  return transport
+  this.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(this.zoomHorizOut, 0, 98)
+  this.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(this.zoomHorizIn, 0, 99)
 }
 
 module.exports = {
@@ -240,6 +252,6 @@ module.exports = {
   masterControl,
   makeLedButton,
   makeTouchFader,
-  makeTransport,
+  Transport,
   bindCommandKnob
 }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -265,17 +265,30 @@ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance, surf
   channelControl.pushEncoder.mEncoderValue.mOnTitleChange = (function (activeDevice, objectTitle, valueTitle) {
     // console.log("Pan Title Changed:" + objectTitle + ":" + valueTitle)
     var activePage = activeDevice.getState("activePage")
+    var activeSubPage = activeDevice.getState("activeSubPage")
     var panTitles = activeDevice.getState(activePage + ' - Pan - Title')
     var panValueTitles = activeDevice.getState(activePage + ' - Pan - ValueTitles')
 
     switch (activePage) {
       case "SelectedTrack":
-        var title = objectTitle.slice(2)
-        if (title.length === 0) {
-          title = "None"
+        switch (activeSubPage) {
+          case "SendsQC":
+            var title = objectTitle.slice(2)
+            if (title.length === 0) {
+              title = "None"
+            }
+            activeDevice.setState(activePage + ' - Pan - ValueTitles', setTextOfColumn(channelIndex, makeLabel(title, 6), panValueTitles))
+            Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+            break;
+          default:
+            var title = valueTitle
+            if (title.length === 0) {
+              title = "None"
+            }
+            activeDevice.setState(activePage + ' - Pan - ValueTitles', setTextOfColumn(channelIndex, makeLabel(title, 6), panValueTitles))
+            Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+            break;
         }
-        activeDevice.setState(activePage + ' - Pan - ValueTitles', setTextOfColumn(channelIndex, makeLabel(title, 6), panValueTitles))
-        Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
         break;
       default:
         activeDevice.setState(activePage + ' - Pan - Title', setTextOfColumn(channelIndex, makeLabel(objectTitle, 6), panTitles))

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -73,7 +73,6 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
 }
 
 /**
- * @constructor
  * @param {MR_DeviceSurface} surface
  * @param {MR_DeviceMidiInput} midiInput
  * @param {MR_DeviceMidiOutput} midiOutput
@@ -96,12 +95,12 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y, 2, 2)
 
   channelControl.pushEncoder.mEncoderValue.mMidiBinding
-    .setInputPort(midiInput)
+    .setInputPort(midiInput).setOutputPort(midiOutput)
     .bindToControlChange(0, 16 + channelControl.instance)
-    .setTypeRelativeSignedBit();
+    .setTypeRelativeSignedBit()
 
   channelControl.pushEncoder.mPushValue.mMidiBinding
-    .setInputPort(midiInput)
+    .setInputPort(midiInput).setOutputPort(midiOutput)
     .bindToNote(0, 32 + channelControl.instance);
 
   // Fader + Fader Touch
@@ -152,10 +151,7 @@ function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
   masterControl.fader_touch = tf[1]
 
   // Channel Buttons
-  // masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1)
-  var mixer_button = surface.makeButton(fader_x + 1, fader_y + 4, 1, 1)
-  masterControl.mixer_button = mixer_button
-  mixer_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 84)
+  masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1)
   masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1)
   masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1)
 
@@ -184,10 +180,7 @@ function makeTransport(surface, midiInput, midiOutput, x, y) {
   transport.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h)
   transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h)
 
-  // TODO Not implemented yet - not sure what to use them for
-  // TODO Perhaps Change the Page in the midi remote??
   transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h)
-  // TODO Not implemented yet - not sure what to use them for
   transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h)
 
   transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h)

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -3,11 +3,6 @@ var makeLabel = helper.display.makeLabel
 var flip = false
 
 function updateDisplay(activeDevice) {
-  if(flip) {
-    midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
-  } else {
-    midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
-  }
   switch (activePage) {
     case "Mixer":
       for (var i = 0; i < surfaceElements.numStrips; ++i) {
@@ -15,19 +10,21 @@ function updateDisplay(activeDevice) {
         if (!flip) {
           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 1, makeLabel(element.faderObjectTitle, 6)))
           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.faderValueTitle, 6)))
+          midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
         }
         else {
           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 1, makeLabel(element.panObjectTitle, 6)))
           midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfColumn(i, 0, makeLabel(element.panValueTitle, 6)))
+          midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
         }
       }
       break;
     case "SelectedTrack":
       var msg = surfaceElements.channelControls[0].trackObjectTitle
       if (!flip) {
+        midiOutput.sendMidi(activeDevice, [0x90, 84, 0]) // Mixer
         // For selected track all the trackObjectTitle are set to the same value
         // So send it once to the display and use the entire top line for the title
-
         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel('QC-' + msg, 56)))
         for (var i = 0; i < surfaceElements.numStrips; ++i) {
           var element = surfaceElements.channelControls[i]
@@ -35,6 +32,7 @@ function updateDisplay(activeDevice) {
         }
       }
       else {
+        midiOutput.sendMidi(activeDevice, [0x90, 84, 127]) // Mixer
         midiOutput.sendMidi(activeDevice, helper.sysex.displaySetTextOfLine(1, makeLabel("Sends-" + msg, 56)))
         for (var i = 0; i < surfaceElements.numStrips; ++i) {
           var element = surfaceElements.channelControls[i]

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -135,9 +135,111 @@ function channelControl(surface, midiInput, midiOutput, x, y, instance) {
 
 }
 
+function repeatCommand(activeDevice, command, repeats) {
+  for (var i = 0; i < repeats; i++) {
+      command.setProcessValue(activeDevice, 1)
+  }
+}
+/**
+ * @param {MR_PushEncoder} pushEncoder
+ * @param {MR_SurfaceCustomValueVariable} commandIncrease
+ * @param {MR_SurfaceCustomValueVariable} commandDecrease
+ */
+ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
+  // console.log('from script: createCommandKnob')
+  pushEncoder.mEncoderValue.mOnProcessValueChange = function (activeDevice, value) {
+      console.log('value changed: ' + value)
+      if (value < 0.5) {
+          var jump_rate = Math.floor(value * 127)
+          repeatCommand(activeDevice, commandIncrease, jump_rate)
+      } else if (value > 0.5) {
+          var jump_rate = Math.floor((value - 0.5) * 127)
+          repeatCommand(activeDevice, commandDecrease, jump_rate)
+      }
+  }
+}
+
+function makeTransport(surface, x, y) {
+  var transport = {}
+  var w = 1
+  var h = 1
+
+  function bindMidiNote(button, chn, num) {
+      button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(chn, num)
+  }
+
+  transport.prevChn = makeLedButton(surface, 48,  x, y, w, h)
+  transport.nextChn = makeLedButton(surface, 49,  x + 1, y, w, h)
+
+  // TODO Not implemented yet - not sure what to use them for
+  // TODO Perhaps Change the Page in the midi remote??
+  transport.prevBnk = makeLedButton(surface, 46, x, y + 1, w, h)
+  // TODO Not implemented yet - not sure what to use them for
+  transport.nextBnk = makeLedButton(surface, 47, x + 1, y + 1, w, h)
+
+  transport.btnRewind = makeLedButton(surface, 91, x, y + 2, w, h)
+  transport.btnForward = makeLedButton(surface, 92, x + 1, y + 2, w, h)
+
+  transport.btnStart = makeLedButton(surface, 94, x, y + 3, w, h)
+  transport.btnStop = makeLedButton(surface, 93, x + 1, y + 3, w, h)
+
+  transport.btnRecord = makeLedButton(surface, 95, x, y + 4, w, h)
+  transport.btnCycle = makeLedButton(surface, 86, x + 1, y + 4, w, h)
+
+  // The Note on/off events for the special functioans are timestamped at the same time
+  // cubase midi remote doesn't show anything on screen though a note is sent
+  // Flip - Simultaneous press of Pre Chn+Pre Bank
+  transport.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
+  bindMidiNote(transport.btnFlip, 0, 50)
+
+  // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
+  // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
+  // If zoom is active and you simply press then other button the event will not be sent
+  //
+  transport.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
+  bindMidiNote(transport.btnZoomOnOff, 0, 100)
+
+  // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
+  // None - CC 60
+  // Vertical - Note Clockwise  97, CounterClockwise 96
+  // Horizontal - Note Clockwise  99, CounterClockwise 98
+  // The Jog wheel is an endless encoder but the surface Push Encoder is control value 0-127
+  // In this case it pays to use the Absolute binding type as the Platform M+ produces a rate based
+  // CC value - turn clockwise slowly -> 1, turn it rapidly -> 7 (counter clockwise values are offset by 50, turn CCW slowly -> 51)
+  // In the Jog (or more correctly Nudge Cursor) mapping we use this to "tap the key severel times" - giving the impact of fine grain control if turned slowly
+  // or large nudges if turned quickly.
+  // ? One weird side effect of this is the Knob displayed in Cubase will show its "value" in a weird way.
+  // todo I wonder if there is a way to change that behaviour?
+
+  transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
+  transport.jog_wheel.mEncoderValue.mMidiBinding
+      .setInputPort(midiInput)
+      .bindToControlChange(0, 60)
+      .setTypeAbsolute()
+  transport.jog_wheel.mPushValue.mMidiBinding
+      .setInputPort(midiInput)
+      .bindToNote(0, 101)
+
+  //Zoom Vertical
+  transport.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomVertOut, 0, 96)
+  transport.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomVertIn, 0, 97)
+
+  //Zoom Horizontal
+  transport.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomHorizOut, 0, 98)
+  transport.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomHorizIn, 0, 99)
+
+  return transport
+}
+
 module.exports = {
   channelControl,
   masterControl,
   makeLedButton,
-  makeTouchFader
+  makeTouchFader,
+  makeTransport,
+  bindCommandKnob
 }

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -1,0 +1,92 @@
+/**
+ * @constructor
+ * @param {MR_DeviceSurface} surface
+ * @param {MR_DeviceMidiInput} midiInput
+ * @param {MR_DeviceMidiOutput} midiOutput
+ * @param {number} x           - x location of the push encoder in the gui
+ * @param {Number} y           - y location of the push encoder in the gui
+ * @param {Number} w           - width of the push encoder.
+ * @param {Number} h           - height of the push encoder.
+ * @param {Number} instance    - instance of the push encoder.
+ */
+function channelControl(surface, midiInput, midiOutput, x, y, instance) {
+  // Position on GUI
+  this.surface = surface;
+  this.midiInput = midiInput;
+  this.midiOutput = midiOutput;
+  this.x = x + 2 * instance;
+  this.y = y;
+  this.instance = instance; // Channel number, 1-8
+
+  this.ident = function () {
+    return ("Class channelControl");
+  }
+
+  this.vPotValue = 0;
+  this.vPotPushValue = 0;
+  this.vFaderValue = 0;
+  this.vFaderTouched = 0;
+  this.vSelLedOn = 0;
+  this.vMuteLedOn = 0;
+  this.vSoloLedOn = 0;
+  this.vRecLedOn = 0;
+
+  // Pot encoder
+  this.pushEncoder = this.surface.makePushEncoder(this.x, y, 2, 2)
+
+  this.pushEncoder.mEncoderValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToControlChange(0, 16 + this.instance)
+    .setTypeRelativeSignedBit();
+
+  this.pushEncoder.mPushValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 32 + this.instance);
+
+  // Fader + Fader Touch
+  var fader_x = this.x
+  var fader_y = y + 3
+  this.fader = surface.makeFader(fader_x, fader_y, 1, 8).setTypeVertical()
+  this.fader.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToPitchBend(this.instance)
+
+  this.fader_touch = surface.makeButton(fader_x + 1, fader_y, 1, 1)
+  this.fader_touch.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 104 + this.instance)
+
+  // Channel Buittons
+  this.sel_button = surface.makeButton(fader_x + 1, fader_y + 4, 1, 1)
+  this.sel_button.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToNote(0, 24 + this.instance)
+
+  this.mute_button = surface.makeButton(fader_x + 1, fader_y + 5, 1, 1)
+  this.mute_button.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 16 + this.instance)
+
+  this.solo_button = surface.makeButton(fader_x + 1, fader_y + 6, 1, 1)
+  this.solo_button.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 8 + this.instance)
+
+  this.rec_button = surface.makeButton(fader_x + 1, fader_y + 7, 1, 1)
+  this.rec_button.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 0 + this.instance)
+}
+
+// channelControl.prototype.setSelLedOn = function (value) {
+//   this.vSelLedOn = value;
+// }
+
+// channelControl.prototype.sendSelLed = function (context) {
+//   this.midiOutput.sendMidi(context, [0x90, this.instance + 24, this.vSelLedOn]);
+// }
+
+module.exports = {
+  channelControl
+}

--- a/icon/platformmplus/icon_elements.js
+++ b/icon/platformmplus/icon_elements.js
@@ -47,102 +47,12 @@ function makeTouchFader(surface, midiInput, midiOutput, channel, x, y, w, h) {
   return [fader, fader_touch]
 }
 
-/**
- * @constructor
- * @param {MR_DeviceSurface} surface
- * @param {MR_DeviceMidiInput} midiInput
- * @param {MR_DeviceMidiOutput} midiOutput
- * @param {number} x           - x location of the push encoder in the gui
- * @param {Number} y           - y location of the push encoder in the gui
- * @param {Number} w           - width of the push encoder.
- * @param {Number} h           - height of the push encoder.
- * @param {Number} instance    - instance of the push encoder.
- */
-function channelControl(surface, midiInput, midiOutput, x, y, instance) {
-  // Position on GUI
-  this.surface = surface;
-  this.midiInput = midiInput;
-  this.midiOutput = midiOutput;
-  this.x = x + 2 * instance;
-  this.y = y;
-  this.instance = instance; // Channel number, 1-8
-
-  this.ident = function () {
-    return ("Class channelControl");
-  }
-
-  // Pot encoder
-  this.pushEncoder = this.surface.makePushEncoder(this.x, y, 2, 2)
-
-  this.pushEncoder.mEncoderValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToControlChange(0, 16 + this.instance)
-    .setTypeRelativeSignedBit();
-
-  this.pushEncoder.mPushValue.mMidiBinding
-    .setInputPort(midiInput)
-    .bindToNote(0, 32 + this.instance);
-
-  // Fader + Fader Touch
-  var fader_x = this.x
-  var fader_y = y + 3
-  var tf = makeTouchFader(surface, midiInput, this.midiOutput, instance, fader_x, fader_y, 1, 8)
-  this.fader = tf[0]
-  this.fader_touch = tf[1]
-
-  // Channel Buttons
-  this.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + this.instance, fader_x + 1, fader_y + 4, 1, 1)
-  this.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + this.instance, fader_x + 1, fader_y + 5, 1, 1)
-  this.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + this.instance, fader_x + 1, fader_y + 6, 1, 1)
-  this.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + this.instance, fader_x + 1, fader_y + 7, 1, 1)
-
-}
-
-/**
- * @param {MR_DeviceSurface} surface
- * @param {MR_DeviceMidiInput} midiInput
- * @param {MR_DeviceMidiOutput} midiOutput
- * @param {number} x           - x location of the push encoder in the gui
- * @param {Number} y           - y location of the push encoder in the gui
- * @param {Number} w           - width of the push encoder.
- * @param {Number} h           - height of the push encoder.
- * @param {Number} instance    - instance of the push encoder.
- */
-function masterControl(surface, midiInput, midiOutput, x, y, instance) {
-  // Position on GUI
-  this.surface = surface;
-  this.midiInput = midiInput;
-  this.midiOutput = midiOutput;
-  this.x = x + 2 * instance;
-  this.y = y;
-  this.instance = instance; // 9 - Master
-
-  this.ident = function () {
-    return ("Class masterControl");
-  }
-
-  // Fader + Fader Touch
-  var fader_x = this.x
-  var fader_y = y + 3
-  var tf = makeTouchFader(surface, midiInput, midiOutput, instance, fader_x, fader_y, 1, 8)
-  this.fader = tf[0]
-  this.fader_touch = tf[1]
-
-  // Channel Buttons
-  // this.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1)
-  var mixer_button = surface.makeButton(fader_x + 1, fader_y + 4, 1, 1)
-  this.mixer_button = mixer_button
-  mixer_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 84)
-  this.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1)
-  this.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1)
-
-}
-
 function repeatCommand(activeDevice, command, repeats) {
   for (var i = 0; i < repeats; i++) {
     command.setProcessValue(activeDevice, 1)
   }
 }
+
 /**
  * @param {MR_SurfaceElementValue} pushEncoder
  * @param {MR_SurfaceCustomValueVariable} commandIncrease
@@ -162,17 +72,108 @@ function bindCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
   }
 }
 
-function Transport(surface, midiInput, midiOutput, x, y) {
-  this.surface = surface;
-  this.midiInput = midiInput;
-  this.midiOutput = midiOutput;
-  this.x = x;
-  this.y = y;
+/**
+ * @constructor
+ * @param {MR_DeviceSurface} surface
+ * @param {MR_DeviceMidiInput} midiInput
+ * @param {MR_DeviceMidiOutput} midiOutput
+ * @param {number} x           - x location of the push encoder in the gui
+ * @param {Number} y           - y location of the push encoder in the gui
+ * @param {Number} w           - width of the push encoder.
+ * @param {Number} h           - height of the push encoder.
+ * @param {Number} instance    - instance of the push encoder.
+ */
+ function makeChannelControl(surface, midiInput, midiOutput, x, y, instance) {
+  var channelControl = {}
+  channelControl.surface = surface;
+  channelControl.midiInput = midiInput;
+  channelControl.midiOutput = midiOutput;
+  channelControl.x = x + 2 * instance;
+  channelControl.y = y;
+  channelControl.instance = instance; // Channel number, 1-8
+
+  // Pot encoder
+  channelControl.pushEncoder = channelControl.surface.makePushEncoder(channelControl.x, y, 2, 2)
+
+  channelControl.pushEncoder.mEncoderValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToControlChange(0, 16 + channelControl.instance)
+    .setTypeRelativeSignedBit();
+
+  channelControl.pushEncoder.mPushValue.mMidiBinding
+    .setInputPort(midiInput)
+    .bindToNote(0, 32 + channelControl.instance);
+
+  // Fader + Fader Touch
+  var fader_x = channelControl.x
+  var fader_y = y + 3
+  var tf = makeTouchFader(surface, midiInput, channelControl.midiOutput, instance, fader_x, fader_y, 1, 8)
+  channelControl.fader = tf[0]
+  channelControl.fader_touch = tf[1]
+
+  // Channel Buttons
+  channelControl.sel_button = makeLedButton(surface, midiInput, midiOutput, 24 + channelControl.instance, fader_x + 1, fader_y + 4, 1, 1)
+  channelControl.mute_button = makeLedButton(surface, midiInput, midiOutput, 16 + channelControl.instance, fader_x + 1, fader_y + 5, 1, 1)
+  channelControl.solo_button = makeLedButton(surface, midiInput, midiOutput, 8 + channelControl.instance, fader_x + 1, fader_y + 6, 1, 1)
+  channelControl.rec_button = makeLedButton(surface, midiInput, midiOutput, 0 + channelControl.instance, fader_x + 1, fader_y + 7, 1, 1)
+
+  return channelControl
+
+}
+
+/**
+ * @param {MR_DeviceSurface} surface
+ * @param {MR_DeviceMidiInput} midiInput
+ * @param {MR_DeviceMidiOutput} midiOutput
+ * @param {number} x           - x location of the push encoder in the gui
+ * @param {Number} y           - y location of the push encoder in the gui
+ * @param {Number} w           - width of the push encoder.
+ * @param {Number} h           - height of the push encoder.
+ * @param {Number} instance    - instance of the push encoder.
+ */
+function makeMasterControl(surface, midiInput, midiOutput, x, y, instance) {
+  var masterControl = {}
+  masterControl.surface = surface;
+  masterControl.midiInput = midiInput;
+  masterControl.midiOutput = midiOutput;
+  masterControl.x = x + 2 * instance;
+  masterControl.y = y;
+  masterControl.instance = instance; // 9 - Master
+
+  masterControl.ident = function () {
+    return ("Class masterControl");
+  }
+
+  // Fader + Fader Touch
+  var fader_x = masterControl.x
+  var fader_y = y + 3
+  var tf = makeTouchFader(surface, midiInput, midiOutput, instance, fader_x, fader_y, 1, 8)
+  masterControl.fader = tf[0]
+  masterControl.fader_touch = tf[1]
+
+  // Channel Buttons
+  // masterControl.mixer_button = makeLedButton(surface, midiInput, midiOutput, 84, fader_x + 1, fader_y + 4, 1, 1)
+  var mixer_button = surface.makeButton(fader_x + 1, fader_y + 4, 1, 1)
+  masterControl.mixer_button = mixer_button
+  mixer_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 84)
+  masterControl.read_button = makeLedButton(surface, midiInput, midiOutput, 74, fader_x + 1, fader_y + 5, 1, 1)
+  masterControl.write_button = makeLedButton(surface, midiInput, midiOutput, 75, fader_x + 1, fader_y + 6, 1, 1)
+
+  return masterControl
+}
+
+function makeTransport(surface, midiInput, midiOutput, x, y) {
+  var transport = {}
+  transport.surface = surface;
+  transport.midiInput = midiInput;
+  transport.midiOutput = midiOutput;
+  transport.x = x;
+  transport.y = y;
 
   var w = 1
   var h = 1
 
-  this.ident = function () {
+  transport.ident = function () {
     return ("Class Transport");
   }
 
@@ -180,36 +181,36 @@ function Transport(surface, midiInput, midiOutput, x, y) {
     button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(chn, num)
   }
 
-  this.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h)
-  this.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h)
+  transport.prevChn = makeLedButton(surface, midiInput, midiOutput, 48, x, y, w, h)
+  transport.nextChn = makeLedButton(surface, midiInput, midiOutput, 49, x + 1, y, w, h)
 
   // TODO Not implemented yet - not sure what to use them for
   // TODO Perhaps Change the Page in the midi remote??
-  this.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h)
+  transport.prevBnk = makeLedButton(surface, midiInput, midiOutput, 46, x, y + 1, w, h)
   // TODO Not implemented yet - not sure what to use them for
-  this.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h)
+  transport.nextBnk = makeLedButton(surface, midiInput, midiOutput, 47, x + 1, y + 1, w, h)
 
-  this.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h)
-  this.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h)
+  transport.btnRewind = makeLedButton(surface, midiInput, midiOutput, 91, x, y + 2, w, h)
+  transport.btnForward = makeLedButton(surface, midiInput, midiOutput, 92, x + 1, y + 2, w, h)
 
-  this.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h)
-  this.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h)
+  transport.btnStart = makeLedButton(surface, midiInput, midiOutput, 94, x, y + 3, w, h)
+  transport.btnStop = makeLedButton(surface, midiInput, midiOutput, 93, x + 1, y + 3, w, h)
 
-  this.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h)
-  this.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h)
+  transport.btnRecord = makeLedButton(surface, midiInput, midiOutput, 95, x, y + 4, w, h)
+  transport.btnCycle = makeLedButton(surface, midiInput, midiOutput, 86, x + 1, y + 4, w, h)
 
   // The Note on/off events for the special functioans are timestamped at the same time
   // cubase midi remote doesn't show anything on screen though a note is sent
   // Flip - Simultaneous press of Pre Chn+Pre Bank
-  this.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
-  bindMidiNote(this.btnFlip, 0, 50)
+  transport.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
+  bindMidiNote(transport.btnFlip, 0, 50)
 
   // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
   // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
   // If zoom is active and you simply press then other button the event will not be sent
   //
-  this.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
-  bindMidiNote(this.btnZoomOnOff, 0, 100)
+  transport.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
+  bindMidiNote(transport.btnZoomOnOff, 0, 100)
 
   // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
   // None - CC 60
@@ -223,38 +224,40 @@ function Transport(surface, midiInput, midiOutput, x, y) {
   // ? One weird side effect of this is the Knob displayed in Cubase will show its "value" in a weird way.
   // todo I wonder if there is a way to change that behaviour?
 
-  this.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
-  this.jog_wheel.mEncoderValue.mMidiBinding
+  transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
+  transport.jog_wheel.mEncoderValue.mMidiBinding
     .setInputPort(midiInput)
     .bindToControlChange(0, 60)
     .setTypeAbsolute()
-  this.jog_wheel.mPushValue.mMidiBinding
+  transport.jog_wheel.mPushValue.mMidiBinding
     .setInputPort(midiInput)
     .bindToNote(0, 101)
   // ? This is still passing midi events through. It's unclear how to stop the midi CC messages passing through other then removing the MIDI port from All In
-  this.jogLeftVariable = surface.makeCustomValueVariable('jogLeft')
-  this.jogRightVariable = surface.makeCustomValueVariable('jogRight')
+  transport.jogLeftVariable = surface.makeCustomValueVariable('jogLeft')
+  transport.jogRightVariable = surface.makeCustomValueVariable('jogRight')
 
-  bindCommandKnob(this.jog_wheel.mEncoderValue, this.jogRightVariable, this.jogLeftVariable);
+  bindCommandKnob(transport.jog_wheel.mEncoderValue, transport.jogRightVariable, transport.jogLeftVariable);
 
   //Zoom Vertical
-  this.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
-  bindMidiNote(this.zoomVertOut, 0, 96)
-  this.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
-  bindMidiNote(this.zoomVertIn, 0, 97)
+  transport.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomVertOut, 0, 96)
+  transport.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomVertIn, 0, 97)
 
   //Zoom Horizontal
-  this.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
-  bindMidiNote(this.zoomHorizOut, 0, 98)
-  this.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
-  bindMidiNote(this.zoomHorizIn, 0, 99)
+  transport.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomHorizOut, 0, 98)
+  transport.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
+  bindMidiNote(transport.zoomHorizIn, 0, 99)
+
+  return transport
 }
 
 module.exports = {
-  channelControl,
-  masterControl,
+  makeChannelControl,
+  makeMasterControl,
+  makeTransport,
   makeLedButton,
   makeTouchFader,
-  Transport,
   bindCommandKnob
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------------
+// 1. DRIVER SETUP - create driver object, midi ports and detection information
+//-----------------------------------------------------------------------------
+
+// get the api's entry point
+var midiremote_api = require('midiremote_api_v1')
+
+// create the device driver main object
+var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'PlatformMPlus', 'Big Fat Wombat')
+
+// create objects representing the hardware's MIDI ports
+var midiInput = deviceDriver.mPorts.makeMidiInput()
+var midiOutput = deviceDriver.mPorts.makeMidiOutput()
+
+// define all possible namings the devices MIDI ports could have
+// NOTE: Windows and MacOS handle port naming differently
+deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
+    .expectInputNameEquals('PlatformMonOut')
+    .expectOutputNameEquals('PlatformMonIn')
+
+deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
+    .expectInputNameEquals('PlatformMonOut')
+    .expectOutputNameEquals('PlatformMonIn')
+
+
+//-----------------------------------------------------------------------------
+// 2. SURFACE LAYOUT - create control elements and midi bindings
+//-----------------------------------------------------------------------------
+
+// create control element representing your hardware's surface
+var knob1 = deviceDriver.mSurface.makeKnob(0, 0, 1, 1.5)
+var knob2 = deviceDriver.mSurface.makeKnob(1, 0, 1, 1.5)
+var knob3 = deviceDriver.mSurface.makeKnob(2, 0, 1, 1.5)
+var knob4 = deviceDriver.mSurface.makeKnob(3, 0, 1, 1.5)
+
+// bind midi ports to surface elements
+knob1.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToControlChange (0, 16).setTypeRelativeSignedBit()
+
+knob2.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToControlChange (0, 17).setTypeRelativeSignedBit()
+
+knob3.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToControlChange (0, 18).setTypeRelativeSignedBit()
+
+knob4.mSurfaceValue.mMidiBinding
+    .setInputPort(midiInput)
+    .setOutputPort(midiOutput)
+    .bindToControlChange (0, 19).setTypeRelativeSignedBit()
+
+//-----------------------------------------------------------------------------
+// 3. HOST MAPPING - create mapping pages and host bindings
+//-----------------------------------------------------------------------------
+
+// create at least one mapping page
+var page = deviceDriver.mMapping.makePage('Example Knobs Page')
+
+// create host accessing objects
+var hostSelectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
+
+
+// bind surface elements to host accessing object values
+page.makeValueBinding(knob1.mSurfaceValue, hostSelectedTrackChannel.mValue.mVolume)
+page.makeValueBinding(knob2.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(0).mLevel)
+page.makeValueBinding(knob3.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(1).mLevel)
+page.makeValueBinding(knob4.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(2).mLevel)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -89,7 +89,7 @@ function makePageWithDefaults(name) {
     var jogSubPageArea = page.makeSubPageArea('Jog')
     var zoomSubPageArea = page.makeSubPageArea('Zoom')
     var subPageJogNudge = makeSubPage(jogSubPageArea, 'Nudge')
-    var subPageJogScrub = makeSubPage(jogSubPageArea, 'Srcub')
+    var subPageJogScrub = makeSubPage(jogSubPageArea, 'Scrub')
     var subPageJogZoom = makeSubPage(zoomSubPageArea, 'Zoom')
     var subPageJobNav = makeSubPage(zoomSubPageArea, 'Nav')
 
@@ -119,7 +119,7 @@ function makePageWithDefaults(name) {
     page.makeActionBinding(surfaceElements.transport.btnZoomOnOff.mSurfaceValue, zoomSubPageArea.mAction.mNext)
 
     // Jog Pages - when Zoom lights are off
-     // Nuge
+    // Nudge
     page.makeCommandBinding(surfaceElements.transport.jogLeftVariable, 'Transport', 'Nudge Cursor Left').setSubPage(subPageJogNudge)
     page.makeCommandBinding(surfaceElements.transport.jogRightVariable, 'Transport', 'Nudge Cursor Right').setSubPage(subPageJogNudge)
     // Scrub (Jog in Cubase)
@@ -198,37 +198,118 @@ function makePageMixer() {
 function makePageSelectedTrack() {
     var page = makePageWithDefaults('Selected Channel')
 
+    var faderSubPageArea = page.makeSubPageArea('Faders')
+    var subPageSendsQC = makeSubPage(faderSubPageArea, 'SendsQC')
+    var subPageEQ = makeSubPage(faderSubPageArea, 'EQ')
+    var subPageCueSends = makeSubPage(faderSubPageArea, 'CueSends')
+    var subPagePreFilter = makeSubPage(faderSubPageArea, 'PreFilter')
+
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
 
+    /// SendsQC subPage
+    // Sends on PushEncodes and mute button for pre/post
+    // Focus QC on Faders
+    // Fader
     for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
         var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
 
-        page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mLevel)
-        page.makeValueBinding(knobPushValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
-        page.makeValueBinding(faderSurfaceValue, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)).setValueTakeOverModeJump()
+        page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mLevel).setSubPage(subPageSendsQC)
+        page.makeValueBinding(knobPushValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle().setSubPage(subPageSendsQC)
+        page.makeValueBinding(faderSurfaceValue, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)).setValueTakeOverModeJump().setSubPage(subPageSendsQC)
 
-        //page.makeValueBinding(surfaceElements.channelControls[idx].sel_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
-        page.makeValueBinding(surfaceElements.channelControls[idx].mute_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mPrePost).setTypeToggle()
-        //page.makeValueBinding(surfaceElements.channelControls[idx].solo_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
+        page.makeValueBinding(surfaceElements.channelControls[idx].sel_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle().setSubPage(subPageSendsQC)
+        page.makeValueBinding(surfaceElements.channelControls[idx].mute_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mPrePost).setTypeToggle().setSubPage(subPageSendsQC)
     }
 
-    page.makeValueBinding(surfaceElements.channelControls[0].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand1.mOn).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[1].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand2.mOn).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[2].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand3.mOn).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[3].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand4.mOn).setTypeToggle()
+    // Handy controls for easy access
+    page.makeCommandBinding(surfaceElements.channelControls[4].solo_button.mSurfaceValue, 'Automation', 'Show Used Automation (Selected Tracks)').setSubPage(subPageSendsQC)
+    page.makeCommandBinding(surfaceElements.channelControls[5].solo_button.mSurfaceValue, 'Automation', 'Hide Automation').setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[6].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[7].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mInstrumentOpen).setTypeToggle().setSubPage(subPageSendsQC)
 
+    page.makeValueBinding(surfaceElements.channelControls[4].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[5].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMute).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[6].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[7].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageSendsQC)
 
-    page.makeCommandBinding(surfaceElements.channelControls[4].solo_button.mSurfaceValue, 'Automation', 'Show Used Automation (Selected Tracks)')
-    page.makeCommandBinding(surfaceElements.channelControls[5].solo_button.mSurfaceValue, 'Automation', 'Hide Automation')
-    page.makeValueBinding(surfaceElements.channelControls[6].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mEditorOpen).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[7].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mInstrumentOpen).setTypeToggle()
+    // EQ Related but on Sends page so you know have EQ activated...not sure the best option but hey, more buttons and lights is cool!
+    page.makeValueBinding(surfaceElements.channelControls[0].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand1.mOn).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[1].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand2.mOn).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[2].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand3.mOn).setTypeToggle().setSubPage(subPageSendsQC)
+    page.makeValueBinding(surfaceElements.channelControls[3].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand4.mOn).setTypeToggle().setSubPage(subPageSendsQC)
 
-    page.makeValueBinding(surfaceElements.channelControls[4].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMonitorEnable).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[5].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMute).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[6].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mSolo).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[7].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mRecordEnable).setTypeToggle()
+    page.makeActionBinding(surfaceElements.channelControls[0].rec_button.mSurfaceValue, subPageSendsQC.mAction.mActivate).setSubPage(subPageSendsQC)
+    page.makeActionBinding(surfaceElements.channelControls[1].rec_button.mSurfaceValue, subPageEQ.mAction.mActivate).setSubPage(subPageSendsQC)
+    page.makeActionBinding(surfaceElements.channelControls[2].rec_button.mSurfaceValue, subPagePreFilter.mAction.mActivate).setSubPage(subPageSendsQC)
+    page.makeActionBinding(surfaceElements.channelControls[3].rec_button.mSurfaceValue, subPageCueSends.mAction.mActivate).setSubPage(subPageSendsQC)
+
+    // EQ Subpage
+    const eqBand = []
+    eqBand[0] = selectedTrackChannel.mChannelEQ.mBand1
+    eqBand[1] = selectedTrackChannel.mChannelEQ.mBand2
+    eqBand[2] = selectedTrackChannel.mChannelEQ.mBand3
+    eqBand[3] = selectedTrackChannel.mChannelEQ.mBand4
+    for (var idx = 0; idx < 4; ++idx) {
+        var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
+        var knob2SurfaceValue = surfaceElements.channelControls[idx+4].pushEncoder.mEncoderValue;
+        var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
+        var knob2PushValue = surfaceElements.channelControls[idx+4].pushEncoder.mPushValue;
+        var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
+        var fader2SurfaceValue = surfaceElements.channelControls[idx + 4].fader.mSurfaceValue;
+
+        page.makeValueBinding(knobSurfaceValue, eqBand[idx].mFilterType).setSubPage(subPageEQ)
+        page.makeValueBinding(knob2SurfaceValue, eqBand[idx].mQ).setSubPage(subPageEQ)
+        page.makeValueBinding(knobPushValue, eqBand[idx].mOn).setTypeToggle().setSubPage(subPageEQ)
+        page.makeValueBinding(knob2PushValue, eqBand[idx].mOn).setTypeToggle().setSubPage(subPageEQ)
+        page.makeValueBinding(faderSurfaceValue, eqBand[idx].mGain).setSubPage(subPageEQ)
+        page.makeValueBinding(fader2SurfaceValue, eqBand[idx].mFreq).setSubPage(subPageEQ)
+    }
+
+    /// CueSends subPage
+    for (var idx = 0; idx < selectedTrackChannel.mCueSends.getSize(); ++idx) {
+        var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
+        var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
+        var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
+
+        page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mCueSends.getByIndex(idx).mPan).setSubPage(subPageCueSends)
+        page.makeValueBinding(knobPushValue, selectedTrackChannel.mCueSends.getByIndex(idx).mOn).setTypeToggle().setSubPage(subPageCueSends)
+        page.makeValueBinding(faderSurfaceValue, selectedTrackChannel.mCueSends.getByIndex(idx).mLevel).setSubPage(subPageCueSends)
+
+        page.makeValueBinding(surfaceElements.channelControls[idx].sel_button.mSurfaceValue, selectedTrackChannel.mCueSends.getByIndex(idx).mOn).setTypeToggle().setSubPage(subPageCueSends)
+        page.makeValueBinding(surfaceElements.channelControls[idx].mute_button.mSurfaceValue, selectedTrackChannel.mCueSends.getByIndex(idx).mPrePost).setTypeToggle().setSubPage(subPageCueSends)
+    }
+
+    // PreFilter subPage
+    var knobSurfaceValue = surfaceElements.channelControls[0].pushEncoder.mEncoderValue;
+    var knob2SurfaceValue = surfaceElements.channelControls[1].pushEncoder.mEncoderValue;
+    var knob3SurfaceValue = surfaceElements.channelControls[2].pushEncoder.mEncoderValue;
+
+    var knobPushValue = surfaceElements.channelControls[0].pushEncoder.mPushValue;
+    var knob2PushValue = surfaceElements.channelControls[1].pushEncoder.mPushValue;
+    var knob3PushValue = surfaceElements.channelControls[2].pushEncoder.mPushValue;
+
+    var faderSurfaceValue = surfaceElements.channelControls[0].fader.mSurfaceValue;
+    var fader2SurfaceValue = surfaceElements.channelControls[1].fader.mSurfaceValue;
+    var fader3SurfaceValue = surfaceElements.channelControls[2].fader.mSurfaceValue;
+
+    var preFilter = selectedTrackChannel.mPreFilter
+
+    page.makeValueBinding(surfaceElements.channelControls[0].sel_button.mSurfaceValue, preFilter.mBypass).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(surfaceElements.channelControls[0].mute_button.mSurfaceValue, preFilter.mPhaseSwitch).setTypeToggle().setSubPage(subPagePreFilter)
+
+    page.makeValueBinding(surfaceElements.channelControls[1].sel_button.mSurfaceValue, preFilter.mHighCutOn).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(surfaceElements.channelControls[2].sel_button.mSurfaceValue, preFilter.mLowCutOn).setTypeToggle().setSubPage(subPagePreFilter)
+
+    page.makeValueBinding(knob2SurfaceValue, preFilter.mHighCutSlope ).setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob3SurfaceValue, preFilter.mLowCutSlope ).setSubPage(subPagePreFilter)
+    page.makeValueBinding(knobPushValue, preFilter.mBypass ).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob2PushValue, preFilter.mHighCutOn ).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob3PushValue, preFilter.mLowCutOn ).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(faderSurfaceValue, preFilter.mGain).setSubPage(subPagePreFilter)
+    page.makeValueBinding(fader2SurfaceValue, preFilter.mHighCutFreq ).setSubPage(subPagePreFilter)
+    page.makeValueBinding(fader3SurfaceValue, preFilter.mLowCutFreq ).setSubPage(subPagePreFilter)
 
     return page
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -441,11 +441,19 @@ function makePageChannelStrip() {
     for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
 
-        page.makeValueBinding(faderSurfaceValue, stripEffects.mGate.mParameterBankZone.makeParameterValue()).setSubPage(gatePage)
-        page.makeValueBinding(faderSurfaceValue, stripEffects.mCompressor.mParameterBankZone.makeParameterValue()).setSubPage(compressorPage)
-        page.makeValueBinding(faderSurfaceValue, stripEffects.mTools.mParameterBankZone.makeParameterValue()).setSubPage(toolsPage)
-        page.makeValueBinding(faderSurfaceValue, stripEffects.mSaturator.mParameterBankZone.makeParameterValue()).setSubPage(saturatorPage)
-        page.makeValueBinding(faderSurfaceValue, stripEffects.mLimiter.mParameterBankZone.makeParameterValue()).setSubPage(limiterPage)
+        var gate = stripEffects.mGate.mParameterBankZone.makeParameterValue()
+        var compressor = stripEffects.mCompressor.mParameterBankZone.makeParameterValue()
+        var tools = stripEffects.mTools.mParameterBankZone.makeParameterValue()
+        var saturator = stripEffects.mSaturator.mParameterBankZone.makeParameterValue()
+        var limiter = stripEffects.mLimiter.mParameterBankZone.makeParameterValue()
+
+        for (var i = 0; i < 2; i++) { // ! Workaround for Cubase 12.0.60+ bug
+            page.makeValueBinding(faderSurfaceValue, gate).setSubPage(gatePage)
+            page.makeValueBinding(faderSurfaceValue, compressor).setSubPage(compressorPage)
+            page.makeValueBinding(faderSurfaceValue, tools).setSubPage(toolsPage)
+            page.makeValueBinding(faderSurfaceValue, saturator).setSubPage(saturatorPage)
+            page.makeValueBinding(faderSurfaceValue, limiter).setSubPage(limiterPage)
+        }
     }
 
     for (var idx = 0; idx < 5; ++idx) {

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -66,8 +66,8 @@ function makeSurfaceElements() {
 
     // Track the selected track name
     surfaceElements.selectedTrack = surface.makeCustomValueVariable('selectedTrack');
-    surfaceElements.selectedTrack.mOnTitleChange = function(activeDevice, objectTitle, valueTitle) {
-        console.log('selectedTrack title change:'+objectTitle)
+    surfaceElements.selectedTrack.mOnTitleChange = function (activeDevice, objectTitle, valueTitle) {
+        console.log('selectedTrack title change:' + objectTitle)
         activeDevice.setState('selectedTrackName', objectTitle)
     }
 
@@ -85,7 +85,7 @@ var surfaceElements = makeSurfaceElements()
 function makeSubPage(subPageArea, name) {
     var subPage = subPageArea.makeSubPage(name)
     var msgText = 'sub page ' + name + ' activated'
-    subPage.mOnActivate = (function (activeDevice) {
+    subPage.mOnActivate = (function (/** @type {MR_ActiveDevice} **/activeDevice) {
         console.log(msgText)
         activeDevice.setState("activeSubPage", name)
         var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
@@ -103,6 +103,39 @@ function makeSubPage(subPageArea, name) {
             case "Zoom":
                 activeDevice.setState("indicator1", "Z")
                 break;
+            case "SendsQC":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 0, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                break;
+            case "EQ":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 1, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                break;
+            case "PreFilter":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 2, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                break;
+            case "CueSends":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 3, 127])
+                break;
+
         }
         Helper_updateDisplay('Row1', 'Row2', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
     }).bind({ subPage, name })
@@ -263,7 +296,6 @@ function makePageSelectedTrack() {
     page.makeActionBinding(surfaceElements.channelControls[2].rec_button.mSurfaceValue, subPagePreFilter.mAction.mActivate).setSubPage(subPageSendsQC)
     page.makeActionBinding(surfaceElements.channelControls[3].rec_button.mSurfaceValue, subPageCueSends.mAction.mActivate).setSubPage(subPageSendsQC)
 
-    // WIP Add Subpage Displays to Selected channel
     // EQ Subpage
     const eqBand = []
     eqBand[0] = selectedTrackChannel.mChannelEQ.mBand1
@@ -424,6 +456,12 @@ selectedTrackPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeD
     activeDevice.setState("activePage", "SelectedTrack")
     clearAllLeds(activeDevice, midiOutput)
     clearChannelState(activeDevice)
+    // Set the Rec leds which correspond to the different subages to their starting state
+    activeDevice.setState("activeSubPage", "SendsQC")
+    midiOutput.sendMidi(activeDevice, [0x90, 0, 127])
+    midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
 }).bind({ midiOutput })
 
 // WIP Add Channel Strip Page

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -48,7 +48,7 @@ function makeSurfaceElements() {
     var surfaceElements = {}
 
     // Display - 2lines
-    surfaceElements.d2Display  = surface.makeBlindPanel(0,0,56,6)
+    surfaceElements.d2Display = surface.makeBlindPanel(0, 0, 56, 6)
 
     surfaceElements.numStrips = 8
 
@@ -61,7 +61,7 @@ function makeSurfaceElements() {
         surfaceElements.channelControls[i] = makeChannelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i)
     }
 
-    surfaceElements.faderMaster = makeMasterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip+4, surfaceElements.numStrips)
+    surfaceElements.faderMaster = makeMasterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip + 4, surfaceElements.numStrips)
     surfaceElements.transport = makeTransport(surface, midiInput, midiOutput, xKnobStrip + 63, yKnobStrip + 4)
 
     return surfaceElements
@@ -274,9 +274,9 @@ function makePageSelectedTrack() {
     eqBand[3] = selectedTrackChannel.mChannelEQ.mBand4
     for (var idx = 0; idx < 4; ++idx) {
         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
-        var knob2SurfaceValue = surfaceElements.channelControls[idx+4].pushEncoder.mEncoderValue;
+        var knob2SurfaceValue = surfaceElements.channelControls[idx + 4].pushEncoder.mEncoderValue;
         var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
-        var knob2PushValue = surfaceElements.channelControls[idx+4].pushEncoder.mPushValue;
+        var knob2PushValue = surfaceElements.channelControls[idx + 4].pushEncoder.mPushValue;
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
         var fader2SurfaceValue = surfaceElements.channelControls[idx + 4].fader.mSurfaceValue;
 
@@ -323,14 +323,14 @@ function makePageSelectedTrack() {
     page.makeValueBinding(surfaceElements.channelControls[1].sel_button.mSurfaceValue, preFilter.mHighCutOn).setTypeToggle().setSubPage(subPagePreFilter)
     page.makeValueBinding(surfaceElements.channelControls[2].sel_button.mSurfaceValue, preFilter.mLowCutOn).setTypeToggle().setSubPage(subPagePreFilter)
 
-    page.makeValueBinding(knob2SurfaceValue, preFilter.mHighCutSlope ).setSubPage(subPagePreFilter)
-    page.makeValueBinding(knob3SurfaceValue, preFilter.mLowCutSlope ).setSubPage(subPagePreFilter)
-    page.makeValueBinding(knobPushValue, preFilter.mBypass ).setTypeToggle().setSubPage(subPagePreFilter)
-    page.makeValueBinding(knob2PushValue, preFilter.mHighCutOn ).setTypeToggle().setSubPage(subPagePreFilter)
-    page.makeValueBinding(knob3PushValue, preFilter.mLowCutOn ).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob2SurfaceValue, preFilter.mHighCutSlope).setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob3SurfaceValue, preFilter.mLowCutSlope).setSubPage(subPagePreFilter)
+    page.makeValueBinding(knobPushValue, preFilter.mBypass).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob2PushValue, preFilter.mHighCutOn).setTypeToggle().setSubPage(subPagePreFilter)
+    page.makeValueBinding(knob3PushValue, preFilter.mLowCutOn).setTypeToggle().setSubPage(subPagePreFilter)
     page.makeValueBinding(faderSurfaceValue, preFilter.mGain).setSubPage(subPagePreFilter)
-    page.makeValueBinding(fader2SurfaceValue, preFilter.mHighCutFreq ).setSubPage(subPagePreFilter)
-    page.makeValueBinding(fader3SurfaceValue, preFilter.mLowCutFreq ).setSubPage(subPagePreFilter)
+    page.makeValueBinding(fader2SurfaceValue, preFilter.mHighCutFreq).setSubPage(subPagePreFilter)
+    page.makeValueBinding(fader3SurfaceValue, preFilter.mLowCutFreq).setSubPage(subPagePreFilter)
 
     return page
 }
@@ -361,7 +361,7 @@ function makePageChannelStrip() {
         page.makeValueBinding(faderSurfaceValue, stripEffects.mLimiter.mParameterBankZone.makeParameterValue()).setSubPage(limiterPage)
     }
 
-  for (var idx = 0; idx < 5; ++idx) {
+    for (var idx = 0; idx < 5; ++idx) {
         var faderStrip = surfaceElements.channelControls[idx]
         var type = ['mGate', 'mCompressor', 'mTools', 'mSaturator', 'mLimiter'][idx]
         page.makeValueBinding(faderStrip.rec_button.mSurfaceValue, stripEffects[type].mOn).setTypeToggle()
@@ -414,21 +414,21 @@ function clearChannelState() {
 }
 mixerPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Mixer" activated')
-    activePage="Mixer"
+    activePage = "Mixer"
     clearAllLeds(device, midiOutput)
     clearChannelState()
 }
 
 selectedTrackPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Selected Track" activated')
-    activePage="SelectedTrack"
+    activePage = "SelectedTrack"
     clearAllLeds(device, midiOutput)
     clearChannelState()
 }
 
 channelStripPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Channel Strip" activated')
-    activePage="ChannelStrip"
+    activePage = "ChannelStrip"
     clearAllLeds(device, midiOutput)
     clearChannelState()
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -30,7 +30,7 @@ var midiOutput = deviceDriver.mPorts.makeMidiOutput()
 deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
     .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonOut
     .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonIn
-
+.
 var surface = deviceDriver.mSurface
 
 //-----------------------------------------------------------------------------
@@ -167,8 +167,10 @@ defaultPage.makeCommandBinding(surfaceElements.transport.zoomHorizIn.mSurfaceVal
 defaultPage.makeCommandBinding(surfaceElements.transport.zoomHorizOut.mSurfaceValue, 'Zoom', 'Zoom Out')
 
 // Transport controls
-defaultPage.makeActionBinding(surfaceElements.transport.prevChn.mSurfaceValue, defaultPage.mHostAccess.mTrackSelection.mAction.mPrevTrack)
-defaultPage.makeActionBinding(surfaceElements.transport.nextChn.mSurfaceValue, defaultPage.mHostAccess.mTrackSelection.mAction.mNextTrack)
+defaultPage.makeCommandBinding(surfaceElements.transport.prevChn.mSurfaceValue, 'Transport', 'Locate Previous Marker')
+defaultPage.makeCommandBinding(surfaceElements.transport.nextChn.mSurfaceValue, 'Transport', 'Locate Next Marker')
+defaultPage.makeCommandBinding(surfaceElements.transport.prevBnk.mSurfaceValue, 'Transport', 'Set Punch In Position')
+defaultPage.makeCommandBinding(surfaceElements.transport.nextBnk.mSurfaceValue, 'Transport', 'Set Punch Out Position')
 defaultPage.makeValueBinding(surfaceElements.transport.btnForward.mSurfaceValue, defaultPage.mHostAccess.mTransport.mValue.mForward)
 defaultPage.makeValueBinding(surfaceElements.transport.btnRewind.mSurfaceValue, defaultPage.mHostAccess.mTransport.mValue.mRewind)
 defaultPage.makeValueBinding(surfaceElements.transport.btnStart.mSurfaceValue, defaultPage.mHostAccess.mTransport.mValue.mStart).setTypeToggle()
@@ -201,6 +203,7 @@ for(var channelIndex = 0; channelIndex < 8; ++channelIndex) {
     var hostMixerBankChannel = hostMixerBankZone.makeMixerBankChannel()
 
     var knobSurfaceValue = surfaceElements.channelControls[channelIndex].pushEncoder.mEncoderValue;
+    var knobPushValue = surfaceElements.channelControls[channelIndex].pushEncoder.mPushValue;
     var faderSurfaceValue = surfaceElements.channelControls[channelIndex].fader.mSurfaceValue;
     var sel_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].sel_button.mSurfaceValue;
     var mute_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].mute_button.mSurfaceValue;
@@ -208,9 +211,24 @@ for(var channelIndex = 0; channelIndex < 8; ++channelIndex) {
     var rec_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].rec_button.mSurfaceValue;
 
     defaultPage.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan)
+    defaultPage.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mInstrumentOpen).setTypeToggle()
     defaultPage.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume)
     defaultPage.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected)
     defaultPage.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle()
     defaultPage.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle()
     defaultPage.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle()
 }
+
+// Master Fader
+// If there is only One output it will be Main
+// ? If there is more than one then this will be the first one
+var ouputMixerBanks = defaultPage.mHostAccess.mMixConsole.makeMixerBankZone().includeOutputChannels()
+var outputMixerBankChannels  = ouputMixerBanks.makeMixerBankChannel()
+defaultPage.makeValueBinding( surfaceElements.faderMaster.fader.mSurfaceValue, outputMixerBankChannels.mValue.mVolume)
+// ? Or connect to headphones
+// defaultPage.makeValueBinding( surfaceElements.faderMaster.fader.mSurfaceValue, defaultPage.mHostAccess.mControlRoom.getPhonesChannelByIndex(0).mLevelValue)
+
+// ? Would be nice to use the read and write buttons as read and write automation for selected track - but haven't figured out how to code that yet
+defaultPage.makeValueBinding( surfaceElements.faderMaster.mixer_button.mSurfaceValue, defaultPage.mHostAccess.mTransport.mValue.mMetronomeActive).setTypeToggle()
+defaultPage.makeValueBinding( surfaceElements.faderMaster.read_button.mSurfaceValue,  defaultPage.mHostAccess.mControlRoom.mMainChannel.mDimActiveValue).setTypeToggle()
+defaultPage.makeValueBinding( surfaceElements.faderMaster.write_button.mSurfaceValue, defaultPage.mHostAccess.mControlRoom.mMainChannel.mReferenceLevelEnabledValue).setTypeToggle()

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -449,10 +449,41 @@ function makePageChannelStrip() {
     return page
 }
 
+function makePageControlRoom() {
+    var page = makePageWithDefaults('ControlRoom')
+
+    var controlRoom = page.mHostAccess.mControlRoom
+
+    // Main
+    page.makeValueBinding(surfaceElements.channelControls[0].fader.mSurfaceValue, controlRoom.mMainChannel.mLevelValue).setValueTakeOverModeJump()
+    page.makeValueBinding(surfaceElements.channelControls[0].mute_button.mSurfaceValue, controlRoom.mMainChannel.mMuteValue).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[0].sel_button.mSurfaceValue, controlRoom.mMainChannel.mMetronomeClickActiveValue).setTypeToggle()
+    // Phones[0]
+    page.makeValueBinding(surfaceElements.channelControls[1].fader.mSurfaceValue, controlRoom.getPhonesChannelByIndex(0).mLevelValue).setValueTakeOverModeJump()
+    page.makeValueBinding(surfaceElements.channelControls[1].mute_button.mSurfaceValue, controlRoom.getPhonesChannelByIndex(0).mMuteValue).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[1].sel_button.mSurfaceValue, controlRoom.getPhonesChannelByIndex(0).mMetronomeClickActiveValue).setTypeToggle()
+
+    var maxCueSends = controlRoom.getMaxCueChannels() < 8 ? controlRoom.getMaxCueChannels() : 8
+
+    for (var i = 0; i < maxCueSends; ++i) {
+        var cueSend = controlRoom.getCueChannelByIndex(i)
+
+        var knobSurfaceValue = surfaceElements.channelControls[i].pushEncoder.mEncoderValue;
+        var knobPushValue = surfaceElements.channelControls[i].pushEncoder.mPushValue;
+
+        page.makeValueBinding(knobSurfaceValue, cueSend.mLevelValue)
+        page.makeValueBinding(knobPushValue, cueSend.mMuteValue).setTypeToggle()
+
+    }
+
+    return page
+}
+
 var mixerPage = makePageMixer()
 var selectedTrackPage = makePageSelectedTrack()
 var channelStripPage = makePageChannelStrip()
 // WIP Add Control Room Page
+var controlRoomPage = makePageControlRoom()
 // WIP Add MIDI CC Page and extra MIDI Port
 
 // Function to clear out the Channel State for the display titles/values
@@ -504,3 +535,10 @@ channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDe
     midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
 }).bind({ midiOutput })
 
+controlRoomPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
+    console.log('from script: Platform M+ page "ControlRoom" activated')
+    activeDevice.setState("activePage", "ControlRoom")
+    clearAllLeds(activeDevice, midiOutput)
+    clearChannelState(activeDevice)
+    console.log("finish cr onactivate")
+}).bind({ midiOutput })

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -140,7 +140,7 @@ function makePageWithDefaults(name) {
     // Master Fader
     // If there is only One output it will be Main
     // If there is more than one out then this will be the first one - there doesn't appear to be a way to verify this
-    var outputMixerBanks = page.mHostAccess.mMixConsole.makeMixerBankZone().includeOutputChannels()
+    var outputMixerBanks = page.mHostAccess.mMixConsole.makeMixerBankZone("OutputBanks").includeOutputChannels()
     var outputMixerBankChannels = outputMixerBanks.makeMixerBankChannel()
     page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, outputMixerBankChannels.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageMasterFaderMain)
     page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, page.mHostAccess.mMouseCursor.mValueUnderMouse).setValueTakeOverModeJump().setSubPage(subPageMasterFaderValue)
@@ -168,7 +168,7 @@ function makePageMixer() {
     var ButtonSubPageArea = page.makeSubPageArea('Buttons')
     var subPageButtonDefaultSet = makeSubPage(ButtonSubPageArea, 'DefaultSet')
 
-    var hostMixerBankZone = page.mHostAccess.mMixConsole.makeMixerBankZone()
+    var hostMixerBankZone = page.mHostAccess.mMixConsole.makeMixerBankZone("AudioInstrBanks")
         .includeAudioChannels()
         .includeInstrumentChannels()
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -38,7 +38,6 @@ deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
     .expectInputNameContains('Platform M+')
     .expectOutputNameContains('Platform M+')
 
-
 var surface = deviceDriver.mSurface
 
 //-----------------------------------------------------------------------------
@@ -171,6 +170,7 @@ function makePageMixer() {
     var hostMixerBankZone = page.mHostAccess.mMixConsole.makeMixerBankZone("AudioInstrBanks")
         .includeAudioChannels()
         .includeInstrumentChannels()
+        .setFollowVisibility(true)
 
     for (var channelIndex = 0; channelIndex < surfaceElements.numStrips; ++channelIndex) {
         var hostMixerBankChannel = hostMixerBankZone.makeMixerBankChannel()
@@ -228,7 +228,7 @@ function makePageSelectedTrack() {
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
 
         // Displays
-        page.setLabelFieldHostObject(surfaceElements.channelControls[idx].displayTop, page.mHostAccess.mFocusedQuickControls) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
+        // page.setLabelFieldHostObject(surfaceElements.channelControls[idx].displayTop, page.mHostAccess.mFocusedQuickControls) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
         page.makeValueBinding(surfaceElements.channelControls[idx].trackNameDisplay, selectedTrackChannel.mValue.mVolume)
         page.makeValueBinding(surfaceElements.channelControls[idx].faderValueDisplay, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)) // for Platform M+ D2 Display
         page.makeValueBinding(surfaceElements.channelControls[idx].panValueDisplay, selectedTrackChannel.mSends.getByIndex(idx).mLevel) // for Platform M+ D2 Display

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -190,6 +190,7 @@ function makePageMixer() {
         // ! Ignoring PC side of display for the moment in favour of the D2 displaying what is required
         page.setLabelFieldHostObject(surfaceElements.channelControls[channelIndex].displayTop, hostMixerBankChannel) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
         // D2
+        page.makeValueBinding(surfaceElements.channelControls[channelIndex].trackNameDisplay, hostMixerBankChannel.mValue.mVolume)
         page.makeValueBinding(surfaceElements.channelControls[channelIndex].faderValueDisplay, hostMixerBankChannel.mValue.mVolume) // for Platform M+ D2 Display
         page.makeValueBinding(surfaceElements.channelControls[channelIndex].panValueDisplay, hostMixerBankChannel.mValue.mPan) // for Platform M+ D2 Display
 
@@ -228,6 +229,7 @@ function makePageSelectedTrack() {
 
         // Displays
         page.setLabelFieldHostObject(surfaceElements.channelControls[idx].displayTop, page.mHostAccess.mFocusedQuickControls) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
+        page.makeValueBinding(surfaceElements.channelControls[idx].trackNameDisplay, selectedTrackChannel.mValue.mVolume)
         page.makeValueBinding(surfaceElements.channelControls[idx].faderValueDisplay, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)) // for Platform M+ D2 Display
         page.makeValueBinding(surfaceElements.channelControls[idx].panValueDisplay, selectedTrackChannel.mSends.getByIndex(idx).mLevel) // for Platform M+ D2 Display
 
@@ -389,19 +391,22 @@ function makePageChannelStrip() {
 var mixerPage = makePageMixer()
 var selectedTrackPage = makePageSelectedTrack()
 var channelStripPage = makePageChannelStrip()
+var activePage = "Mixer"
 
 mixerPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Mixer" activated')
-
+    activePage="Mixer"
     clearAllLeds(device, midiOutput)
 }
 
 selectedTrackPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Selected Track" activated')
+    activePage="SelectedTrack"
     clearAllLeds(device, midiOutput)
 }
 
 channelStripPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Channel Strip" activated')
+    activePage="ChannelStrip"
     clearAllLeds(device, midiOutput)
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -181,9 +181,10 @@ function makePageMixer() {
 
         // FaderKnobs - Volume, Pan, Editor Open
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
-        page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageFaderVolume)
+        page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(faderTouchSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageFaderVolume)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -83,6 +83,7 @@ function makeSubPage(subPageArea, name) {
         var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
         ]
         switch (name) {
+            // WIP This should probably be handled by state variables and made part of update display
             case "Scrub":
                 var out = data.concat(55, "S".charCodeAt(0))
                 out.push(0xf7)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -31,12 +31,12 @@ deviceDriver.mOnActivate = function (activeDevice) {
 
 // define all possible namings the devices MIDI ports could have
 // NOTE: Windows and MacOS handle port naming differently
-// deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-//     .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
-//     .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
 deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-    .expectInputNameContains('Platform M+')
-    .expectOutputNameContains('Platform M+')
+    .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
+    .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
+// deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
+//     .expectInputNameContains('Platform M+')
+//     .expectOutputNameContains('Platform M+')
 // ? I wonder if this can be figured out?
 // .expectSysexIdentityResponse(/*vendor id (1 or 3 bytes, here: 3 bytes)*/'00n1n2', /*device family*/'n1n2', /*model number*/'n1n2')
 
@@ -66,6 +66,43 @@ function makeSurfaceElements() {
 }
 
 var surfaceElements = makeSurfaceElements()
+
+
+function faderDisplayFeedback() {
+    surfaceElements.channelControls[0].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(0, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+
+    surfaceElements.channelControls[1].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(1, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+
+    surfaceElements.channelControls[2].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(2, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+
+    surfaceElements.channelControls[3].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(3, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+
+    surfaceElements.channelControls[4].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(4, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+    surfaceElements.channelControls[5].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(5, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+    surfaceElements.channelControls[6].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(6, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+    surfaceElements.channelControls[7].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
+        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(7, 0, makeStringMax6CharectersAndRemoveSpace(value)))
+    }
+
+    function makeStringMax6CharectersAndRemoveSpace(value) {
+        //return value.length > 6 ? value.replace(/\s/g, '').slice(0, 6) : value
+        return value.replace(/\s/g, '').slice(0, 6)
+    }
+}
 
 //-----------------------------------------------------------------------------
 // 3. HOST MAPPING - create mapping mixerPages and host bindings

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -58,11 +58,11 @@ function makeSurfaceElements() {
     var yKnobStrip = 5
 
     for (var i = 0; i < surfaceElements.numStrips; ++i) {
-        surfaceElements.channelControls[i] = makeChannelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i)
+        surfaceElements.channelControls[i] = makeChannelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i, surfaceElements)
     }
 
-    surfaceElements.faderMaster = makeMasterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip + 4, surfaceElements.numStrips)
-    surfaceElements.transport = makeTransport(surface, midiInput, midiOutput, xKnobStrip + 63, yKnobStrip + 4)
+    surfaceElements.faderMaster = makeMasterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip + 4, surfaceElements.numStrips, surfaceElements)
+    surfaceElements.transport = makeTransport(surface, midiInput, midiOutput, xKnobStrip + 63, yKnobStrip + 4, surfaceElements)
 
     return surfaceElements
 }
@@ -404,8 +404,6 @@ function makePageChannelStrip() {
 var mixerPage = makePageMixer()
 var selectedTrackPage = makePageSelectedTrack()
 var channelStripPage = makePageChannelStrip()
-var activePage = "Mixer"
-var activeSubPage = "Nudge"
 
 // Function to clear out the Channel State for the display titles/values
 // the OnDisplayChange callback is not called if the Channel doesn't have an updated
@@ -422,24 +420,24 @@ function clearChannelState() {
         surfaceElements.channelControls[i].panPushValue = ""
     }
 }
-mixerPage.mOnActivate = function (device) {
+mixerPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     console.log('from script: Platform M+ page "Mixer" activated')
-    activePage = "Mixer"
-    clearAllLeds(device, midiOutput)
+    activeDevice.setState("activePage","Mixer")
+    clearAllLeds(activeDevice, midiOutput)
     clearChannelState()
-}
+}).bind({ midiOutput })
 
-selectedTrackPage.mOnActivate = function (device) {
+selectedTrackPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     console.log('from script: Platform M+ page "Selected Track" activated')
-    activePage = "SelectedTrack"
-    clearAllLeds(device, midiOutput)
+     activeDevice.setState("activePage","SelectedTrack")
+    clearAllLeds(activeDevice, midiOutput)
     clearChannelState()
-}
+}).bind({ midiOutput })
 
-channelStripPage.mOnActivate = function (device) {
+channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     console.log('from script: Platform M+ page "Channel Strip" activated')
-    activePage = "ChannelStrip"
-    clearAllLeds(device, midiOutput)
+     activeDevice.setState("activePage","ChannelStrip")
+    clearAllLeds(activeDevice, midiOutput)
     clearChannelState()
-}
+}).bind({ midiOutput })
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -459,8 +459,10 @@ function makePageChannelStrip() {
     for (var idx = 0; idx < 5; ++idx) {
         var faderStrip = surfaceElements.channelControls[idx]
         var type = ['mGate', 'mCompressor', 'mTools', 'mSaturator', 'mLimiter'][idx]
-        page.makeValueBinding(faderStrip.rec_button.mSurfaceValue, stripEffects[type].mOn).setTypeToggle()
-        page.makeValueBinding(faderStrip.mute_button.mSurfaceValue, stripEffects[type].mBypass).setTypeToggle()
+        for (var i = 0; i < 2; i++) { // ! Workaround for Cubase 12.0.60+ bug
+            page.makeValueBinding(faderStrip.rec_button.mSurfaceValue, stripEffects[type].mOn).setTypeToggle()
+            page.makeValueBinding(faderStrip.mute_button.mSurfaceValue, stripEffects[type].mBypass).setTypeToggle()
+        }
     }
 
     page.makeActionBinding(surfaceElements.channelControls[0].sel_button.mSurfaceValue, gatePage.mAction.mActivate)
@@ -584,9 +586,9 @@ selectedTrackPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeD
 channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     console.log('from script: Platform M+ page "Channel Strip" activated')
     activeDevice.setState("activePage", "ChannelStrip")
+    activeDevice.setState("activeSubPage", "Gate")
     clearAllLeds(activeDevice, midiOutput)
     clearChannelState(activeDevice)
-    activeDevice.setState("activeSubPage", "Gate")
     midiOutput.sendMidi(activeDevice, [0x90, 24, 127])
     midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
     midiOutput.sendMidi(activeDevice, [0x90, 26, 0])

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -183,7 +183,7 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        // page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)
@@ -193,7 +193,7 @@ function makePageMixer() {
 }
 
 function makePageSelectedTrack() {
-    var page = makePageWithDefaults('Selected Track')
+    var page = makePageWithDefaults('Selected Channel')
 
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -49,8 +49,6 @@ function makeSurfaceElements() {
 
     // Display - 2lines
     surfaceElements.d2Display  = surface.makeBlindPanel(0,0,56,6)
-    surfaceElements.displayTop = surface.makeLabelField(0,1,56,2)
-    surfaceElements.displayBottom =  surface.makeLabelField(0,3,56,2)
 
     surfaceElements.numStrips = 8
 
@@ -186,6 +184,11 @@ function makePageMixer() {
         var solo_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].solo_button.mSurfaceValue;
         var rec_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].rec_button.mSurfaceValue;
 
+        // Displays
+        page.setLabelFieldHostObject(surfaceElements.channelControls[channelIndex].displayTop, hostMixerBankChannel) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
+        page.makeValueBinding(surfaceElements.channelControls[channelIndex].faderValueDisplay, hostMixerBankChannel.mValue.mVolume) // for Platform M+ D2 Display
+        page.makeValueBinding(surfaceElements.channelControls[channelIndex].panValueDisplay, hostMixerBankChannel.mValue.mPan) // for Platform M+ D2 Display
+
         // FaderKnobs - Volume, Pan, Editor Open
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
@@ -219,6 +222,11 @@ function makePageSelectedTrack() {
         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
         var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
+
+        // Displays
+        page.setLabelFieldHostObject(surfaceElements.channelControls[idx].displayTop, page.mHostAccess.mFocusedQuickControls) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
+        page.makeValueBinding(surfaceElements.channelControls[idx].faderValueDisplay, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)) // for Platform M+ D2 Display
+        page.makeValueBinding(surfaceElements.channelControls[idx].panValueDisplay, selectedTrackChannel.mSends.getByIndex(idx).mLevel) // for Platform M+ D2 Display
 
         page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mLevel).setSubPage(subPageSendsQC)
         page.makeValueBinding(knobPushValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle().setSubPage(subPageSendsQC)
@@ -378,10 +386,10 @@ function makePageChannelStrip() {
 var mixerPage = makePageMixer()
 var selectedTrackPage = makePageSelectedTrack()
 var channelStripPage = makePageChannelStrip()
-// var quadPage = makePageQuad()
 
 mixerPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Mixer" activated')
+
     clearAllLeds(device, midiOutput)
 }
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -118,7 +118,9 @@ function makeTransport(x, y) {
     // In this case it pays to use the Absolute binding type as the Platform M+ produces a rate based
     // CC value - turn clockwise slowly -> 1, turn it rapidly -> 7 (counter clockwise values are offset by 50, turn CCW slowly -> 51)
     // In the Jog (or more correctly Nudge Cursor) mapping we use this to "tap the key severel times" - giving the impact of fine grain control if turned slowly
-    // or large nudges if turned quickly
+    // or large nudges if turned quickly.
+    // ? One weird side effect of this is the Knob displayed in Cubase will show its "value" in a weird way.
+    // todo I wonder if there is a way to change that behaviour?
 
     transport.jog_wheel = surface.makePushEncoder(x, y + 6, 2, 2)
     transport.jog_wheel.mEncoderValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 60).setTypeAbsolute()

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -15,58 +15,118 @@ var midiOutput = deviceDriver.mPorts.makeMidiOutput()
 // define all possible namings the devices MIDI ports could have
 // NOTE: Windows and MacOS handle port naming differently
 deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-    .expectInputNameEquals('PlatformMonOut')
-    .expectOutputNameEquals('PlatformMonIn')
+    .expectInputNameEquals('PlatformMonOut') // Platform M+ v2.15
+    .expectOutputNameEquals('PlatformMonIn') // Platform M+ v2.15
 
-deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-    .expectInputNameEquals('PlatformMonOut')
-    .expectOutputNameEquals('PlatformMonIn')
-
+var surface = deviceDriver.mSurface
 
 //-----------------------------------------------------------------------------
 // 2. SURFACE LAYOUT - create control elements and midi bindings
 //-----------------------------------------------------------------------------
 
-// create control element representing your hardware's surface
-var knob1 = deviceDriver.mSurface.makeKnob(0, 0, 1, 1.5)
-var knob2 = deviceDriver.mSurface.makeKnob(1, 0, 1, 1.5)
-var knob3 = deviceDriver.mSurface.makeKnob(2, 0, 1, 1.5)
-var knob4 = deviceDriver.mSurface.makeKnob(3, 0, 1, 1.5)
+function makeKnobStrip(knobIndex, x, y) {
+    var knobStrip = {}
 
-// bind midi ports to surface elements
-knob1.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .setOutputPort(midiOutput)
-    .bindToControlChange (0, 16).setTypeRelativeSignedBit()
+    knobStrip.knob = surface.makeKnob(x + 2 * knobIndex, y, 1, 1)
+    knobStrip.knob.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 16 + knobIndex).setTypeRelativeSignedBit()
 
-knob2.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .setOutputPort(midiOutput)
-    .bindToControlChange (0, 17).setTypeRelativeSignedBit()
+    return knobStrip
+}
 
-knob3.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .setOutputPort(midiOutput)
-    .bindToControlChange (0, 18).setTypeRelativeSignedBit()
+function makeFaderStrip(channelIndex, x, y) {
+    var faderStrip = {}
 
-knob4.mSurfaceValue.mMidiBinding
-    .setInputPort(midiInput)
-    .setOutputPort(midiOutput)
-    .bindToControlChange (0, 19).setTypeRelativeSignedBit()
+    // Fader + Fader Touch
+    faderStrip.fader = surface.makeFader(x + 2 * channelIndex, y, 1, 8).setTypeVertical()
+    faderStrip.fader.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToPitchBend(channelIndex)
+
+    faderStrip.touched = surface.makeButton(x + 1+ 2 * channelIndex, y, 1, 1)
+    faderStrip.touched.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 104 + channelIndex)
+
+    // Channel Buittons
+    faderStrip.sel_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 4, 1, 1)
+    faderStrip.sel_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 24 + channelIndex)
+
+    faderStrip.mute_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 5, 1, 1)
+    faderStrip.mute_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 16 + channelIndex)
+
+    faderStrip.solo_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 6, 1, 1)
+    faderStrip.solo_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 8 + channelIndex)
+
+    faderStrip.rec_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 7, 1, 1)
+    faderStrip.rec_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 0 + channelIndex)
+
+    return faderStrip
+}
+
+function makeTransport(x, y) {
+    var transport = {}
+
+    var w = 1
+    var h = 1
+
+    function bindMidiNote(button, chn, num) {
+        button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(chn, num)
+    }
+
+    transport.prevChn = surface.makeButton(x, y, w, h)
+    bindMidiNote(transport.prevChn, 0, 48)
+    transport.nextChn = surface.makeButton(x+1, y, w, h)
+    bindMidiNote(transport.nextChn, 0, 49)
+
+    transport.prevBnk = surface.makeButton(x, y+1, w, h)
+    bindMidiNote(transport.prevBnk, 0, 46)
+    transport.nextBnk = surface.makeButton(x+1, y+1, w, h)
+    bindMidiNote(transport.nextBnk, 0, 47)
+
+    transport.btnRewind = surface.makeButton(x, y+2, w, h)
+    bindMidiNote(transport.btnRewind, 0, 91)
+    transport.btnForward = surface.makeButton(x+1, y+2, w, h)
+    bindMidiNote(transport.btnForward, 0, 92)
+
+    transport.btnStart = surface.makeButton(x, y+3, w, h)
+    bindMidiNote(transport.btnStart, 0, 94)
+    transport.btnStop = surface.makeButton(x+1, y+3, w, h)
+    bindMidiNote(transport.btnStop, 0, 93)
+
+    transport.btnRecord = surface.makeButton(x, y+4, w, h)
+    bindMidiNote(transport.btnRecord, 0, 95)
+    transport.btnCycle = surface.makeButton(x+1, y+4, w, h)
+    bindMidiNote(transport.btnCycle, 0, 86)
+
+    //jog wheel
+    transport.jog_wheel = surface.makeKnob(x, y + 6, 2, 2)
+    transport.jog_wheel.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 60).setTypeRelativeSignedBit()
+    transport.btnJog = surface.makeButton(x,y+8,2,1)
+    bindMidiNote(transport.btnJog, 0, 101)
+
+    return transport
+}
+
+function makeSurfaceElements() {
+    var surfaceElements = {}
+
+    surfaceElements.numStrips = 8
+
+    surfaceElements.knobStrips = {}
+    surfaceElements.faderStrips = {}
+
+    var xKnobStrip = 0
+    var yKnobStrip = 0
+
+    for(var i = 0; i < surfaceElements.numStrips; ++i) {
+        surfaceElements.knobStrips[i] = makeKnobStrip(i, xKnobStrip, yKnobStrip)
+        surfaceElements.faderStrips[i] = makeFaderStrip(i, xKnobStrip, yKnobStrip+2)
+    }
+
+    surfaceElements.transport = makeTransport(20, 3)
+
+    return surfaceElements
+}
+
+var surfaceElements = makeSurfaceElements()
+
 
 //-----------------------------------------------------------------------------
 // 3. HOST MAPPING - create mapping pages and host bindings
 //-----------------------------------------------------------------------------
-
-// create at least one mapping page
-var page = deviceDriver.mMapping.makePage('Example Knobs Page')
-
-// create host accessing objects
-var hostSelectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
-
-
-// bind surface elements to host accessing object values
-page.makeValueBinding(knob1.mSurfaceValue, hostSelectedTrackChannel.mValue.mVolume)
-page.makeValueBinding(knob2.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(0).mLevel)
-page.makeValueBinding(knob3.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(1).mLevel)
-page.makeValueBinding(knob4.mSurfaceValue, hostSelectedTrackChannel.mSends.getByIndex(2).mLevel)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -275,6 +275,7 @@ function makePageSelectedTrack() {
     page.makeActionBinding(surfaceElements.channelControls[2].rec_button.mSurfaceValue, subPagePreFilter.mAction.mActivate).setSubPage(subPageSendsQC)
     page.makeActionBinding(surfaceElements.channelControls[3].rec_button.mSurfaceValue, subPageCueSends.mAction.mActivate).setSubPage(subPageSendsQC)
 
+    // WIP Add Subpage Displays to Selected channel
     // EQ Subpage
     const eqBand = []
     eqBand[0] = selectedTrackChannel.mChannelEQ.mBand1

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -68,42 +68,6 @@ function makeSurfaceElements() {
 var surfaceElements = makeSurfaceElements()
 
 
-function faderDisplayFeedback() {
-    surfaceElements.channelControls[0].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(0, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-
-    surfaceElements.channelControls[1].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(1, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-
-    surfaceElements.channelControls[2].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(2, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-
-    surfaceElements.channelControls[3].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(3, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-
-    surfaceElements.channelControls[4].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(4, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-    surfaceElements.channelControls[5].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(5, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-    surfaceElements.channelControls[6].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(6, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-    surfaceElements.channelControls[7].fader.mSurfaceValue.mOnDisplayValueChange = function (context, value, units) {
-        midiOutput.sendMidi(context, helper.sysex.displaySetTextOfColumn(7, 0, makeStringMax6CharectersAndRemoveSpace(value)))
-    }
-
-    function makeStringMax6CharectersAndRemoveSpace(value) {
-        //return value.length > 6 ? value.replace(/\s/g, '').slice(0, 6) : value
-        return value.replace(/\s/g, '').slice(0, 6)
-    }
-}
-
 //-----------------------------------------------------------------------------
 // 3. HOST MAPPING - create mapping mixerPages and host bindings
 //-----------------------------------------------------------------------------

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -28,8 +28,8 @@ var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'Platform Mplus', 'Bi
 // create objects representing the hardware's MIDI ports
 var midiInput = deviceDriver.mPorts.makeMidiInput('Platform M+')
 var midiOutput = deviceDriver.mPorts.makeMidiOutput('Platform M+')
-// var midiPageInput = deviceDriver.mPorts.makeMidiInput('Icon - CC - In')
-var midiPageOutput = deviceDriver.mPorts.makeMidiOutput('Icon - CC - Out')
+var midiPageInput = deviceDriver.mPorts.makeMidiInput('Icon CC')
+var midiPageOutput = deviceDriver.mPorts.makeMidiOutput('Icon CC')
 
 deviceDriver.mOnActivate = function (activeDevice) {
     console.log('Icon Platform M+ Activated');
@@ -46,9 +46,8 @@ deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
     .expectInputNameContains('Platform M+')
     .expectOutputNameContains('Platform M+')
 
-// deviceDriver.makeDetectionUnit().detectPortPair(midiPageInput, midiPageOutput)
-//     .expectInputNameEquals('Icon - CC - In')
-//     .expectOutputNameEquals('Icon - CC - Out')
+deviceDriver.makeDetectionUnit().detectPortPair(midiPageInput, midiPageOutput)
+    .expectOutputNameEquals('Icon CC')
 
 var surface = deviceDriver.mSurface
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -304,8 +304,6 @@ function makePageMixer() {
     var subPageButtonDefaultSet = makeSubPage(ButtonSubPageArea, 'DefaultSet')
 
     var hostMixerBankZone = page.mHostAccess.mMixConsole.makeMixerBankZone("AudioInstrBanks")
-        .includeAudioChannels()
-        .includeInstrumentChannels()
         .setFollowVisibility(true)
 
     for (var channelIndex = 0; channelIndex < surfaceElements.numStrips; ++channelIndex) {

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -5,9 +5,9 @@
 // - Mackie C4 by Ron Garrison <ron.garrison@gmail.com> https://github.com/rwgarrison/midiremote-userscripts
 
 var iconElements = require('./icon_elements.js')
-var channelControl = iconElements.channelControl
-var masterControl = iconElements.masterControl
-var Transport = iconElements.Transport
+var makeChannelControl = iconElements.makeChannelControl
+var makeMasterControl = iconElements.makeMasterControl
+var makeTransport = iconElements.makeTransport
 
 //-----------------------------------------------------------------------------
 // 1. DRIVER SETUP - create driver object, midi ports and detection information
@@ -54,11 +54,11 @@ function makeSurfaceElements() {
     var yKnobStrip = 0
 
     for (var i = 0; i < surfaceElements.numStrips; ++i) {
-        surfaceElements.channelControls[i] = new channelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i)
+        surfaceElements.channelControls[i] = makeChannelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i)
     }
 
-    surfaceElements.faderMaster = new masterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip, surfaceElements.numStrips)
-    surfaceElements.transport = new Transport(surface, midiInput, midiOutput, xKnobStrip + 20, yKnobStrip + 3)
+    surfaceElements.faderMaster = makeMasterControl(surface, midiInput, midiOutput, xKnobStrip + 1, yKnobStrip, surfaceElements.numStrips)
+    surfaceElements.transport = makeTransport(surface, midiInput, midiOutput, xKnobStrip + 20, yKnobStrip + 3)
 
     return surfaceElements
 }
@@ -181,10 +181,9 @@ function makePageMixer() {
 
         // FaderKnobs - Volume, Pan, Editor Open
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
-        page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
+        page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(faderTouchSurfaceValue, hostMixerBankChannel.mValue.mSelected).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
+        // page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)
@@ -197,7 +196,6 @@ function makePageSelectedTrack() {
     var page = makePageWithDefaults('Selected Track')
 
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
-
 
     for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -164,8 +164,8 @@ function makePageMixer() {
     var subPageButtonDefaultSet = makeSubPage(ButtonSubPageArea, 'DefaultSet')
 
     var hostMixerBankZone = page.mHostAccess.mMixConsole.makeMixerBankZone()
-        .excludeOutputChannels()
-        .excludeInputChannels()
+        .includeAudioChannels()
+        .includeInstrumentChannels()
 
     for (var channelIndex = 0; channelIndex < surfaceElements.numStrips; ++channelIndex) {
         var hostMixerBankChannel = hostMixerBankZone.makeMixerBankChannel()
@@ -173,6 +173,7 @@ function makePageMixer() {
         var knobSurfaceValue = surfaceElements.channelControls[channelIndex].pushEncoder.mEncoderValue;
         var knobPushValue = surfaceElements.channelControls[channelIndex].pushEncoder.mPushValue;
         var faderSurfaceValue = surfaceElements.channelControls[channelIndex].fader.mSurfaceValue;
+        var faderTouchSurfaceValue = surfaceElements.channelControls[channelIndex].fader_touch.mSurfaceValue;
         var sel_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].sel_button.mSurfaceValue;
         var mute_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].mute_button.mSurfaceValue;
         var solo_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].solo_button.mSurfaceValue;
@@ -182,7 +183,8 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(faderTouchSurfaceValue, hostMixerBankChannel.mValue.mSelected).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -8,7 +8,6 @@ var iconElements = require('./icon_elements.js')
 var channelControl = iconElements.channelControl
 var masterControl = iconElements.masterControl
 var Transport = iconElements.Transport
-var bindCommandKnob = iconElements.bindCommandKnob
 
 //-----------------------------------------------------------------------------
 // 1. DRIVER SETUP - create driver object, midi ports and detection information
@@ -23,6 +22,10 @@ var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'Platform Mplus', 'Bi
 // create objects representing the hardware's MIDI ports
 var midiInput = deviceDriver.mPorts.makeMidiInput()
 var midiOutput = deviceDriver.mPorts.makeMidiOutput()
+
+deviceDriver.mOnActivate = function (activeDevice) {
+    console.log('Icon Platform M+ Initialized');
+};
 
 // define all possible namings the devices MIDI ports could have
 // NOTE: Windows and MacOS handle port naming differently
@@ -164,7 +167,7 @@ function makePageMixer() {
         .excludeOutputChannels()
         .excludeInputChannels()
 
-    for (var channelIndex = 0; channelIndex < 8; ++channelIndex) {
+    for (var channelIndex = 0; channelIndex < surfaceElements.numStrips; ++channelIndex) {
         var hostMixerBankChannel = hostMixerBankZone.makeMixerBankChannel()
 
         var knobSurfaceValue = surfaceElements.channelControls[channelIndex].pushEncoder.mEncoderValue;
@@ -179,7 +182,7 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setValueTakeOverModeJump().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)
@@ -194,14 +197,10 @@ function makePageSelectedTrack() {
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
 
 
-    for (var idx = 0; idx < 8; ++idx) {
+    for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
         var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
-        var sel_buttonSurfaceValue = surfaceElements.channelControls[idx].sel_button.mSurfaceValue;
-        var mute_buttonSurfaceValue = surfaceElements.channelControls[idx].mute_button.mSurfaceValue;
-        var solo_buttonSurfaceValue = surfaceElements.channelControls[idx].solo_button.mSurfaceValue;
-        var rec_buttonSurfaceValue = surfaceElements.channelControls[idx].rec_button.mSurfaceValue;
 
         page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mLevel)
         page.makeValueBinding(knobPushValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -145,16 +145,8 @@ function makePageWithDefaults(name) {
     // var subPageMasterFaderMain = makeSubPage(MasterFaderSubPageArea, 'MF_MainOut')
 
 
-    // Master Fader
-    // If there is only One output it will be Main
-    // If there is more than one out then this will be the first one - there doesn't appear to be a way to verify this
-    // var outputMixerBanks = page.mHostAccess.mMixConsole.makeMixerBankZone("OutputBanks").includeOutputChannels()
-    // var outputMixerBankChannels = outputMixerBanks.makeMixerBankChannel()
+    // Master Fader changes display detail
     page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, page.mHostAccess.mMouseCursor.mValueUnderMouse).setValueTakeOverModeJump().setSubPage(subPageMasterFaderValue)
-    // page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, outputMixerBankChannels.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageMasterFaderMain)
-
-    // Switch Master Fader to Main Out<->Value Under Cursor (AI)
-    // page.makeActionBinding(surfaceElements.faderMaster.mixer_button.mSurfaceValue, MasterFaderSubPageArea.mAction.mNext)
 
     // Automation for selected tracks
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -80,6 +80,30 @@ function makeSubPage(subPageArea, name) {
     var msgText = 'sub page ' + name + ' activated'
     subPage.mOnActivate = function (activeDevice) {
         console.log(msgText)
+        var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
+        ]
+        switch (name) {
+            case "Scrub":
+                var out = data.concat(55, "S".charCodeAt(0))
+                out.push(0xf7)
+                midiOutput.sendMidi(activeDevice, out)
+                break;
+            case "Nudge":
+                var out = data.concat(55, "N".charCodeAt(0))
+                out.push(0xf7)
+                midiOutput.sendMidi(activeDevice, out)
+                break;
+            case "Nav":
+                var out = data.concat(111, "N".charCodeAt(0))
+                out.push(0xf7)
+                midiOutput.sendMidi(activeDevice, out)
+                break;
+            case "Zoom":
+                var out = data.concat(111, "Z".charCodeAt(0))
+                out.push(0xf7)
+                midiOutput.sendMidi(activeDevice, out)
+                break;
+        }
     }
     return subPage
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -288,6 +288,7 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
+        page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume) // ! Duplicate to overcome C12.0.60+ bug
         page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -122,15 +122,15 @@ function makeTransport(x, y) {
     bindMidiNote(transport.btnJog, 0, 101)
 
     //Zoom Vertical
-    transport.zoomVertOut = surface.makeButton(x+3, y + 6, 1, 1)
+    transport.zoomVertOut = surface.makeButton(x+3, y + 6, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomVertOut, 0, 96)
-    transport.zoomVertIn = surface.makeButton(x+4, y + 6, 1, 1)
+    transport.zoomVertIn = surface.makeButton(x+4, y + 6, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomVertIn, 0, 97)
 
     //Zoom Horizontal
-    transport.zoomHorizOut = surface.makeButton(x+3, y + 7, 1, 1)
+    transport.zoomHorizOut = surface.makeButton(x+3, y + 7, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomHorizOut, 0, 98)
-    transport.zoomHorizIn = surface.makeButton(x+4, y + 7, 1, 1)
+    transport.zoomHorizIn = surface.makeButton(x+4, y + 7, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomHorizIn, 0, 99)
 
     return transport
@@ -164,3 +164,12 @@ var surfaceElements = makeSurfaceElements()
 //-----------------------------------------------------------------------------
 // 3. HOST MAPPING - create mapping pages and host bindings
 //-----------------------------------------------------------------------------
+
+var page = deviceDriver.mMapping.makePage('Default')
+
+page.makeCommandBinding(surfaceElements.transport.zoomVertIn.mSurfaceValue, 'Zoom', 'Zoom In Vertically')
+page.makeCommandBinding(surfaceElements.transport.zoomVertOut.mSurfaceValue, 'Zoom', 'Zoom Out Vertically')
+
+page.makeCommandBinding(surfaceElements.transport.zoomHorizIn.mSurfaceValue, 'Zoom', 'Zoom In')
+page.makeCommandBinding(surfaceElements.transport.zoomHorizOut.mSurfaceValue, 'Zoom', 'Zoom Out')
+

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -142,19 +142,19 @@ function makePageWithDefaults(name) {
 
     var MasterFaderSubPageArea = page.makeSubPageArea('MasterFader')
     var subPageMasterFaderValue = makeSubPage(MasterFaderSubPageArea, 'MF_ValueUnderCursor')
-    var subPageMasterFaderMain = makeSubPage(MasterFaderSubPageArea, 'MF_MainOut')
+    // var subPageMasterFaderMain = makeSubPage(MasterFaderSubPageArea, 'MF_MainOut')
 
 
     // Master Fader
     // If there is only One output it will be Main
     // If there is more than one out then this will be the first one - there doesn't appear to be a way to verify this
-    var outputMixerBanks = page.mHostAccess.mMixConsole.makeMixerBankZone("OutputBanks").includeOutputChannels()
-    var outputMixerBankChannels = outputMixerBanks.makeMixerBankChannel()
+    // var outputMixerBanks = page.mHostAccess.mMixConsole.makeMixerBankZone("OutputBanks").includeOutputChannels()
+    // var outputMixerBankChannels = outputMixerBanks.makeMixerBankChannel()
     page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, page.mHostAccess.mMouseCursor.mValueUnderMouse).setValueTakeOverModeJump().setSubPage(subPageMasterFaderValue)
-    page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, outputMixerBankChannels.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageMasterFaderMain)
+    // page.makeValueBinding(surfaceElements.faderMaster.fader.mSurfaceValue, outputMixerBankChannels.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageMasterFaderMain)
 
     // Switch Master Fader to Main Out<->Value Under Cursor (AI)
-    page.makeActionBinding(surfaceElements.faderMaster.mixer_button.mSurfaceValue, MasterFaderSubPageArea.mAction.mNext)
+    // page.makeActionBinding(surfaceElements.faderMaster.mixer_button.mSurfaceValue, MasterFaderSubPageArea.mAction.mNext)
 
     // Automation for selected tracks
     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -6,7 +6,7 @@
 var midiremote_api = require('midiremote_api_v1')
 
 // create the device driver main object
-var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'PlatformMPlus', 'Big Fat Wombat')
+var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'Platform Mplus', 'Big Fat Wombat')
 
 // create objects representing the hardware's MIDI ports
 var midiInput = deviceDriver.mPorts.makeMidiInput()
@@ -29,6 +29,8 @@ function makeKnobStrip(knobIndex, x, y) {
 
     knobStrip.knob = surface.makeKnob(x + 2 * knobIndex, y, 1, 1)
     knobStrip.knob.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 16 + knobIndex).setTypeRelativeSignedBit()
+    knobStrip.touched = surface.makeButton(x + 2 * knobIndex, y+1, 1, 1)
+    knobStrip.touched.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 32 + knobIndex)
 
     return knobStrip
 }
@@ -94,11 +96,42 @@ function makeTransport(x, y) {
     transport.btnCycle = surface.makeButton(x+1, y+4, w, h)
     bindMidiNote(transport.btnCycle, 0, 86)
 
+    // ! The Note on/off events for the special functioans are timestamped at the same time
+    // ! cubase midi remote doesn't show anything on screen though a note is sent
+
+    // Flip - Simultaneous press of Pre Chn+Pre Bank
+    transport.btnFlip = surface.makeButton(x+3, y+4, 1, 1)
+    bindMidiNote(transport.btnFlip, 0, 50)
+
+    // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
+    // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
+    // If zoom is active and you simply press then other button the event will not be sent
+    //
+    transport.btnZoomOnOff= surface.makeButton(x+4, y+4, 1, 1)
+    bindMidiNote(transport.btnZoomOnOff, 0, 100)
+
+
+    // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
+    // None - CC 60
+    // Vertical - Note Clockwise  97, CounterClockwise 96
+    // Horizontal - Note Clockwise  99, CounterClockwise 98
     //jog wheel
     transport.jog_wheel = surface.makeKnob(x, y + 6, 2, 2)
     transport.jog_wheel.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 60).setTypeRelativeSignedBit()
     transport.btnJog = surface.makeButton(x,y+8,2,1)
     bindMidiNote(transport.btnJog, 0, 101)
+
+    //Zoom Vertical
+    transport.zoomVertOut = surface.makeButton(x+3, y + 6, 1, 1)
+    bindMidiNote(transport.zoomVertOut, 0, 96)
+    transport.zoomVertIn = surface.makeButton(x+4, y + 6, 1, 1)
+    bindMidiNote(transport.zoomVertIn, 0, 97)
+
+    //Zoom Horizontal
+    transport.zoomHorizOut = surface.makeButton(x+3, y + 7, 1, 1)
+    bindMidiNote(transport.zoomHorizOut, 0, 98)
+    transport.zoomHorizIn = surface.makeButton(x+4, y + 7, 1, 1)
+    bindMidiNote(transport.zoomHorizIn, 0, 99)
 
     return transport
 }
@@ -116,10 +149,11 @@ function makeSurfaceElements() {
 
     for(var i = 0; i < surfaceElements.numStrips; ++i) {
         surfaceElements.knobStrips[i] = makeKnobStrip(i, xKnobStrip, yKnobStrip)
-        surfaceElements.faderStrips[i] = makeFaderStrip(i, xKnobStrip, yKnobStrip+2)
+        surfaceElements.faderStrips[i] = makeFaderStrip(i, xKnobStrip, yKnobStrip+3)
     }
 
-    surfaceElements.transport = makeTransport(20, 3)
+    surfaceElements.faderMaster = makeFaderStrip(surfaceElements.numStrips, xKnobStrip+1, yKnobStrip+3)
+    surfaceElements.transport = makeTransport(xKnobStrip+20, yKnobStrip+3)
 
     return surfaceElements
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -96,102 +96,124 @@ function makeSubPage(subPageArea, name) {
     var msgText = 'sub page ' + name + ' activated'
     subPage.mOnActivate = (function (/** @type {MR_ActiveDevice} **/activeDevice) {
         // console.log(msgText)
-        activeDevice.setState("activeSubPage", name)
-        var data = [0xf0, 0x00, 0x00, 0x66, 0x14, 0x12,
-        ]
-        switch (name) {
-            case "Scrub":
-                activeDevice.setState("indicator2", "S")
+        var activePage = activeDevice.getState("activePage")
+        var activeSubPage = this.name
+        switch(activePage) {
+            case "SelectedTrack":
+                switch (activeSubPage) {
+                    case "SendsQC":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the rec button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 0, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "EQ":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the rec button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 1, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "PreFilter":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the rec button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 2, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "CueSends":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the rec button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 3, 127])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                }
                 break;
-            case "Nudge":
-                activeDevice.setState("indicator2", "N")
+            case "ChannelStrip":
+                switch (activeSubPage) {
+                    case "Gate":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the sel button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 24, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "Compressor":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the sel button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 25, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "Tools":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the sel button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 26, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "Saturator":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the sel button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 27, 127])
+                        midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                    case "Limiter":
+                        // An action binding cannot be set to a Toggle type button so manually adjust the sel button lights
+                        // based on the subpage selection.
+                        midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                        midiOutput.sendMidi(activeDevice, [0x90, 28, 127])
+                        activeDevice.setState("activeSubPage", activeSubPage)
+                        break;
+                }
                 break;
-            case "Nav":
-                activeDevice.setState("indicator1", "N")
-                break;
-            case "Zoom":
-                activeDevice.setState("indicator1", "Z")
-                break;
-            case "SendsQC":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 0, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
-                break;
-            case "EQ":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 1, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
-                break;
-            case "PreFilter":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 2, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
-                break;
-            case "CueSends":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the rec button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 0, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 1, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 3, 127])
-                break;
-            case "Gate":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 24, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
-                break;
-            case "Compressor":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 25, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
-                break;
-            case "Tools":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 26, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
-                break;
-            case "Saturator":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 27, 127])
-                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
-                break;
-            case "Limiter":
-                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
-                // based on the subpage selection.
-                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
-                midiOutput.sendMidi(activeDevice, [0x90, 28, 127])
-                break;
+            default:
+                // WIP activeSubPage for these is non-sensical as they are global
+                switch (activeSubPage) {
+                    case "Scrub":
+                        activeDevice.setState("indicator2", "S")
+                        break;
+                    case "Nudge":
+                        activeDevice.setState("indicator2", "N")
+                        break;
+                    case "Nav":
+                        activeDevice.setState("indicator1", "N")
+                        break;
+                    case "Zoom":
+                        activeDevice.setState("indicator1", "Z")
+                        break;
+                }
+            // ! Do not set activeSubPage for these
+            break;
         }
         Helper_updateDisplay('Row1', 'Row2', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
-    }).bind({ subPage, name })
+    }).bind({ name })
     return subPage
 }
 /**
@@ -254,6 +276,20 @@ function makePageWithDefaults(name) {
     // Automation for selected tracks
     page.makeValueBinding(surfaceElements.faderMaster.read_button.mSurfaceValue, selectedTrackChannel.mValue.mAutomationRead).setTypeToggle()
     page.makeValueBinding(surfaceElements.faderMaster.write_button.mSurfaceValue, selectedTrackChannel.mValue.mAutomationWrite).setTypeToggle()
+
+    // Mixer Button
+    var display_type = page.mCustom.makeHostValueVariable("Mixer - display type")
+    page.makeValueBinding(surfaceElements.faderMaster.mixer_button.mSurfaceValue, display_type).setTypeToggle().mOnValueChange = function (activeDevice, mapping, value, value2) {
+        // console.log("display_type OnValueChange:"+value+":"+value2)
+        if(value===0)
+        {
+            activeDevice.setState("displayType", "Fader")
+        } else {
+            activeDevice.setState("displayType", "Pan")
+        }
+        // Update controller
+        Helper_updateDisplay(activeDevice.getState('Display - idRow1'), activeDevice.getState('Display - idRow2'), activeDevice.getState('Display - idAltRow1'), activeDevice.getState('Display - idAltRow2'), activeDevice, midiOutput)
+    }
 
     return page
 }
@@ -338,7 +374,7 @@ function makePageSelectedTrack() {
             onTitleChange: function(activeDevice,activeMapping,objectTitle, valueTitle) {
                 var activePage = activeDevice.getState("activePage")
                 var activeSubPage = activeDevice.getState("activeSubPage")
-                var faderValueTitles = activeDevice.getState(activePage + ' - Fader - ValueTitles')
+                var faderValueTitles = activeDevice.getState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles')
                 // console.log("QC Title Changed:" +this.idx+":" + objectTitle + ":" + valueTitle)
                 switch (activePage) {
                 case "SelectedTrack":
@@ -348,8 +384,8 @@ function makePageSelectedTrack() {
                             if (title.length === 0) {
                                 title = "None"
                             }
-                            activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(this.idx, makeLabel(title, 6), faderValueTitles))
-                            Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+                            activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', setTextOfColumn(this.idx, makeLabel(title, 6), faderValueTitles))
+                            Helper_updateDisplay(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', activePage + "- " + activeSubPage + ' - Fader - Values', activePage + "- " + activeSubPage + ' - Pan - ValueTitles', activePage + "- " + activeSubPage + ' - Pan - Values', activeDevice, midiOutput)
                             break;
                     }
                     break;
@@ -554,8 +590,10 @@ function makePageMidi() {
             .mOnValueChange = function (activeDevice, mapping, value, value2) {
                 // console.log(displayName + ":" + mapping + "::" + value + "::" + value2)
                 var activePage = activeDevice.getState("activePage")
-                var faderValueTitles = activeDevice.getState(activePage + ' - Fader - ValueTitles')
-                var faderValues = activeDevice.getState(activePage + ' - Fader - Values')
+                var activeSubPage = activeDevice.getState("activeSubPage")
+
+                var faderValueTitles = activeDevice.getState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles')
+                var faderValues = activeDevice.getState(activePage + "- " + activeSubPage + ' - Fader - Values')
 
                 var ccValue = Math.ceil(value * 127)
                 var pitchBendValue = Math.ceil(value * 16383)
@@ -567,9 +605,9 @@ function makePageMidi() {
                 // this is the value going back to Cubendo
                 midiPageOutput.sendMidi(activeDevice, [0xB0, cc, ccValue])
                 // and this updates the D2 Display
-                activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfColumn(fader, makeLabel(displayName, 6), faderValueTitles))
-                activeDevice.setState(activePage + ' - Fader - Values', setTextOfColumn(fader, makeLabel(ccValue.toString(), 6), faderValues))
-                Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+                activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', setTextOfColumn(fader, makeLabel(displayName, 6), faderValueTitles))
+                activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - Values', setTextOfColumn(fader, makeLabel(ccValue.toString(), 6), faderValues))
+                Helper_updateDisplay(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', activePage + "- " + activeSubPage + ' - Fader - Values', activePage + "- " + activeSubPage + ' - Pan - ValueTitles', activePage + "- " + activeSubPage + ' - Pan - Values', activeDevice, midiOutput)
             }
     }
 
@@ -592,20 +630,22 @@ var midiPage = makePageMidi()
 // in the state. By clearing state on the page activation it will update all that are changing.
 function clearChannelState(/** @type {MR_ActiveDevice} */activeDevice) {
     var activePage = activeDevice.getState("activePage")
+    var activeSubPage = activeDevice.getState("activeSubPage")
     // console.log('from script: clearChannelState'+activePage)
 
-    activeDevice.setState(activePage + ' - Fader - Title', "")
-    activeDevice.setState(activePage + ' - Fader - ValueTitles', "")
-    activeDevice.setState(activePage + ' - Fader - Values', "")
-    activeDevice.setState(activePage + ' - Pan - Title', "")
-    activeDevice.setState(activePage + ' - Pan - ValueTitles', "")
-    activeDevice.setState(activePage + ' - Pan - Values', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - Title', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - Values', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Pan - Title', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Pan - ValueTitles', "")
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Pan - Values', "")
 
     activeDevice.setState("displayType", "Fader")
 }
 mixerPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     // console.log('from script: Platform M+ page "Mixer" activated')
     activeDevice.setState("activePage", "Mixer")
+    activeDevice.setState("activeSubPage", "Default")
     clearAllLeds(activeDevice, midiOutput)
     clearChannelState(activeDevice)
 }).bind({ midiOutput })
@@ -634,11 +674,13 @@ channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDe
     midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
     midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
     midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+    // Helper_updateDisplay("ChannelStrip" + "- " + "Gate" + ' - Fader - ValueTitles', "ChannelStrip" + "- " + "Gate" + ' - Fader - Values', "ChannelStrip" + "- " + "Gate" + ' - Pan - ValueTitles', "ChannelStrip" + "- " + "Gate" + ' - Pan - Values', activeDevice, midiOutput)
 }).bind({ midiOutput })
 
 controlRoomPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
     // console.log('from script: Platform M+ page "ControlRoom" activated')
     activeDevice.setState("activePage", "ControlRoom")
+    activeDevice.setState("activeSubPage", "Default")
     clearAllLeds(activeDevice, midiOutput)
     clearChannelState(activeDevice)
 }).bind({ midiOutput })
@@ -646,13 +688,16 @@ controlRoomPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDev
 midiPage.mOnActivate = function (/** @type {MR_ActiveDevice} */activeDevice) {
     // console.log('from script: Platform M+ page "Midi" activated')
     var activePage = "Midi"
+    var activeSubPage = "Default"
     activeDevice.setState("activePage", activePage)
+    activeDevice.setState("activeSubPage", activeSubPage)
     clearAllLeds(activeDevice, midiOutput)
+    clearChannelState(activeDevice)
     // ! This init must match the CC bindings create in the makeMidiPage function - it's annoying and needs a refactor
     // WIP Refactor me
-    var faderValueTitles = activeDevice.getState(activePage + ' - Fader - ValueTitles')
+    var faderValueTitles = activeDevice.getState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles')
     faderValueTitles = setTextOfColumn(0, makeLabel("CC1", 6), faderValueTitles)
     faderValueTitles = setTextOfColumn(1, makeLabel("CC11", 6), faderValueTitles)
-    activeDevice.setState(activePage + ' - Fader - ValueTitles', setTextOfLine(faderValueTitles))
-    Helper_updateDisplay(activePage + ' - Fader - ValueTitles', activePage + ' - Fader - Values', activePage + ' - Pan - ValueTitles', activePage + ' - Pan - Values', activeDevice, midiOutput)
+    activeDevice.setState(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', setTextOfLine(faderValueTitles))
+    Helper_updateDisplay(activePage + "- " + activeSubPage + ' - Fader - ValueTitles', activePage + "- " + activeSubPage + ' - Fader - Values', activePage + "- " + activeSubPage + ' - Pan - ValueTitles', activePage + "- " + activeSubPage + ' - Pan - Values', activeDevice, midiOutput)
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -80,14 +80,6 @@ function makeSubPage(subPageArea, name) {
     var msgText = 'sub page ' + name + ' activated'
     subPage.mOnActivate = function (activeDevice) {
         console.log(msgText)
-        switch (name) {
-            case "MF_MainOut":
-                midiOutput.sendMidi(activeDevice, [0x90, 84, 127])
-                break;
-            case "MF_ValueUnderCursor":
-                midiOutput.sendMidi(activeDevice, [0x90, 84, 0])
-                break;
-        }
     }
     return subPage
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -177,7 +177,7 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setValueTakeOverModeJump().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setValueTakeOverModeJump().setSubPage(subPageButtonDefaultSet)
 
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -8,6 +8,7 @@ var iconElements = require('./icon_elements.js')
 var makeChannelControl = iconElements.makeChannelControl
 var makeMasterControl = iconElements.makeMasterControl
 var makeTransport = iconElements.makeTransport
+var clearAllLeds = iconElements.clearAllLeds
 
 //-----------------------------------------------------------------------------
 // 1. DRIVER SETUP - create driver object, midi ports and detection information
@@ -24,7 +25,8 @@ var midiInput = deviceDriver.mPorts.makeMidiInput()
 var midiOutput = deviceDriver.mPorts.makeMidiOutput()
 
 deviceDriver.mOnActivate = function (activeDevice) {
-    console.log('Icon Platform M+ Initialized');
+    console.log('Icon Platform M+ Activated');
+    clearAllLeds(activeDevice, midiOutput)
 };
 
 // define all possible namings the devices MIDI ports could have
@@ -227,8 +229,10 @@ var selectedTrackPage = makePageSelectedTrack()
 
 mixerPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Mixer" activated')
+    clearAllLeds(device, midiOutput)
 }
 
 selectedTrackPage.mOnActivate = function (device) {
     console.log('from script: Platform M+ page "Selected Track" activated')
+    clearAllLeds(device, midiOutput)
 }

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -1,3 +1,14 @@
+// Icon Platform M+ midi Remote
+// Robert Woodcock
+//
+// Portions of this implementation where inspired by other midi remote creates to whom I wish to say thank you!
+// - Mackie C4 by Ron Garrison <ron.garrison@gmail.com> https://github.com/rwgarrison/midiremote-userscripts
+
+var sw_rev = '0.0.0'
+
+var iconElements = require('./icon_elements.js');
+var channelControl = iconElements.channelControl;
+
 //-----------------------------------------------------------------------------
 // 1. DRIVER SETUP - create driver object, midi ports and detection information
 //-----------------------------------------------------------------------------
@@ -6,7 +17,7 @@
 var midiremote_api = require('midiremote_api_v1')
 
 // create the device driver main object
-var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'Platform Mplus', 'Big Fat Wombat')
+var deviceDriver = midiremote_api.makeDeviceDriver('Icon', 'Platform Mplus', 'Big Fat Wombats')
 
 // create objects representing the hardware's MIDI ports
 var midiInput = deviceDriver.mPorts.makeMidiInput()
@@ -15,8 +26,8 @@ var midiOutput = deviceDriver.mPorts.makeMidiOutput()
 // define all possible namings the devices MIDI ports could have
 // NOTE: Windows and MacOS handle port naming differently
 deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-    .expectInputNameEquals('PlatformMonOut') // Platform M+ v2.15
-    .expectOutputNameEquals('PlatformMonIn') // Platform M+ v2.15
+    .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonOut
+    .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonIn
 
 var surface = deviceDriver.mSurface
 
@@ -24,46 +35,8 @@ var surface = deviceDriver.mSurface
 // 2. SURFACE LAYOUT - create control elements and midi bindings
 //-----------------------------------------------------------------------------
 
-function makeKnobStrip(knobIndex, x, y) {
-    var knobStrip = {}
-
-    knobStrip.knob = surface.makeKnob(x + 2 * knobIndex, y, 1, 1)
-    knobStrip.knob.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToControlChange(0, 16 + knobIndex).setTypeRelativeSignedBit()
-    knobStrip.touched = surface.makeButton(x + 2 * knobIndex, y+1, 1, 1)
-    knobStrip.touched.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 32 + knobIndex)
-
-    return knobStrip
-}
-
-function makeFaderStrip(channelIndex, x, y) {
-    var faderStrip = {}
-
-    // Fader + Fader Touch
-    faderStrip.fader = surface.makeFader(x + 2 * channelIndex, y, 1, 8).setTypeVertical()
-    faderStrip.fader.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToPitchBend(channelIndex)
-
-    faderStrip.touched = surface.makeButton(x + 1+ 2 * channelIndex, y, 1, 1)
-    faderStrip.touched.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 104 + channelIndex)
-
-    // Channel Buittons
-    faderStrip.sel_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 4, 1, 1)
-    faderStrip.sel_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 24 + channelIndex)
-
-    faderStrip.mute_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 5, 1, 1)
-    faderStrip.mute_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 16 + channelIndex)
-
-    faderStrip.solo_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 6, 1, 1)
-    faderStrip.solo_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 8 + channelIndex)
-
-    faderStrip.rec_button = surface.makeButton(x + 1 + 2 * channelIndex, y + 7, 1, 1)
-    faderStrip.rec_button.mSurfaceValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 0 + channelIndex)
-
-    return faderStrip
-}
-
 function makeTransport(x, y) {
     var transport = {}
-
     var w = 1
     var h = 1
 
@@ -73,41 +46,44 @@ function makeTransport(x, y) {
 
     transport.prevChn = surface.makeButton(x, y, w, h)
     bindMidiNote(transport.prevChn, 0, 48)
-    transport.nextChn = surface.makeButton(x+1, y, w, h)
+    transport.nextChn = surface.makeButton(x + 1, y, w, h)
     bindMidiNote(transport.nextChn, 0, 49)
 
-    transport.prevBnk = surface.makeButton(x, y+1, w, h)
+    transport.prevBnk = surface.makeButton(x, y + 1, w, h)
     bindMidiNote(transport.prevBnk, 0, 46)
-    transport.nextBnk = surface.makeButton(x+1, y+1, w, h)
+    transport.nextBnk = surface.makeButton(x + 1, y + 1, w, h)
     bindMidiNote(transport.nextBnk, 0, 47)
 
-    transport.btnRewind = surface.makeButton(x, y+2, w, h)
+    transport.btnRewind = surface.makeButton(x, y + 2, w, h)
     bindMidiNote(transport.btnRewind, 0, 91)
-    transport.btnForward = surface.makeButton(x+1, y+2, w, h)
+    transport.btnForward = surface.makeButton(x + 1, y + 2, w, h)
     bindMidiNote(transport.btnForward, 0, 92)
 
-    transport.btnStart = surface.makeButton(x, y+3, w, h)
-    bindMidiNote(transport.btnStart, 0, 94)
-    transport.btnStop = surface.makeButton(x+1, y+3, w, h)
+    transport.btnStart = surface.makeButton(x, y + 3, w, h)
+    // bindMidiNote(transport.btnStart, 0, 94)
+    transport.start_state = deviceDriver.mSurface.makeCustomValueVariable('start_state')
+    transport.start_state.mMidiBinding.setInputPort(midiInput).bindToNote(0, 94)
+
+    transport.btnStop = surface.makeButton(x + 1, y + 3, w, h)
     bindMidiNote(transport.btnStop, 0, 93)
 
-    transport.btnRecord = surface.makeButton(x, y+4, w, h)
+    transport.btnRecord = surface.makeButton(x, y + 4, w, h)
     bindMidiNote(transport.btnRecord, 0, 95)
-    transport.btnCycle = surface.makeButton(x+1, y+4, w, h)
+    transport.btnCycle = surface.makeButton(x + 1, y + 4, w, h)
     bindMidiNote(transport.btnCycle, 0, 86)
 
     // ! The Note on/off events for the special functioans are timestamped at the same time
     // ! cubase midi remote doesn't show anything on screen though a note is sent
 
     // Flip - Simultaneous press of Pre Chn+Pre Bank
-    transport.btnFlip = surface.makeButton(x+3, y+4, 1, 1)
+    transport.btnFlip = surface.makeButton(x + 3, y + 4, 1, 1)
     bindMidiNote(transport.btnFlip, 0, 50)
 
     // Pressing the Zoom keys simultaneously will toggle on and off a note event. If on
     // either zoom button will send a Note 100 when zoom is activated or deactivated by either button
     // If zoom is active and you simply press then other button the event will not be sent
     //
-    transport.btnZoomOnOff= surface.makeButton(x+4, y+4, 1, 1)
+    transport.btnZoomOnOff = surface.makeButton(x + 4, y + 4, 1, 1)
     bindMidiNote(transport.btnZoomOnOff, 0, 100)
 
     // The Jog wheel will change CC/Note based on which of thte Zoom buttons have been activated
@@ -127,15 +103,15 @@ function makeTransport(x, y) {
     transport.jog_wheel.mPushValue.mMidiBinding.setInputPort(midiInput).bindToNote(0, 101)
 
     //Zoom Vertical
-    transport.zoomVertOut = surface.makeButton(x+3, y + 6, 1, 1).setShapeCircle()
+    transport.zoomVertOut = surface.makeButton(x + 3, y + 6, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomVertOut, 0, 96)
-    transport.zoomVertIn = surface.makeButton(x+4, y + 6, 1, 1).setShapeCircle()
+    transport.zoomVertIn = surface.makeButton(x + 4, y + 6, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomVertIn, 0, 97)
 
     //Zoom Horizontal
-    transport.zoomHorizOut = surface.makeButton(x+3, y + 7, 1, 1).setShapeCircle()
+    transport.zoomHorizOut = surface.makeButton(x + 3, y + 7, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomHorizOut, 0, 98)
-    transport.zoomHorizIn = surface.makeButton(x+4, y + 7, 1, 1).setShapeCircle()
+    transport.zoomHorizIn = surface.makeButton(x + 4, y + 7, 1, 1).setShapeCircle()
     bindMidiNote(transport.zoomHorizIn, 0, 99)
 
     return transport
@@ -146,50 +122,66 @@ function makeSurfaceElements() {
 
     surfaceElements.numStrips = 8
 
-    surfaceElements.knobStrips = {}
-    surfaceElements.faderStrips = {}
+    surfaceElements.channelControls = {}
 
     var xKnobStrip = 0
     var yKnobStrip = 0
 
-    for(var i = 0; i < surfaceElements.numStrips; ++i) {
-        surfaceElements.knobStrips[i] = makeKnobStrip(i, xKnobStrip, yKnobStrip)
-        surfaceElements.faderStrips[i] = makeFaderStrip(i, xKnobStrip, yKnobStrip+3)
+    for (var i = 0; i < surfaceElements.numStrips; ++i) {
+        surfaceElements.channelControls[i] = new channelControl(surface, midiInput, midiOutput, xKnobStrip, yKnobStrip, i)
     }
 
-    surfaceElements.faderMaster = makeFaderStrip(surfaceElements.numStrips, xKnobStrip+1, yKnobStrip+3)
-    surfaceElements.transport = makeTransport(xKnobStrip+20, yKnobStrip+3)
+    // surfaceElements.faderMaster = makeFaderStrip(surfaceElements.numStrips, xKnobStrip+1, yKnobStrip+3)
+    surfaceElements.transport = makeTransport(xKnobStrip + 20, yKnobStrip + 3)
 
     return surfaceElements
 }
 
 var surfaceElements = makeSurfaceElements()
 
+function makeTransportDisplayFeedback(button, ledID) {
+    button.mSurfaceValue.mOnProcessValueChange = function (context, newValue) {
+        midiOutput.sendMidi(context, [0x90, ledID, newValue])
+    }
+}
+makeTransportDisplayFeedback(surfaceElements.transport.btnStart, 94)
 
 //-----------------------------------------------------------------------------
-// 3. HOST MAPPING - create mapping pages and host bindings
+// 3. HOST MAPPING - create mapping defaultPages and host bindings
 //-----------------------------------------------------------------------------
 
-var page = deviceDriver.mMapping.makePage('Default')
+var defaultPage = deviceDriver.mMapping.makePage('Default')
 
-page.makeCommandBinding(surfaceElements.transport.zoomVertIn.mSurfaceValue, 'Zoom', 'Zoom In Vertically')
-page.makeCommandBinding(surfaceElements.transport.zoomVertOut.mSurfaceValue, 'Zoom', 'Zoom Out Vertically')
+defaultPage.makeCommandBinding(surfaceElements.transport.zoomVertIn.mSurfaceValue, 'Zoom', 'Zoom In Vertically')
+defaultPage.makeCommandBinding(surfaceElements.transport.zoomVertOut.mSurfaceValue, 'Zoom', 'Zoom Out Vertically')
 
-page.makeCommandBinding(surfaceElements.transport.zoomHorizIn.mSurfaceValue, 'Zoom', 'Zoom In')
-page.makeCommandBinding(surfaceElements.transport.zoomHorizOut.mSurfaceValue, 'Zoom', 'Zoom Out')
+defaultPage.makeCommandBinding(surfaceElements.transport.zoomHorizIn.mSurfaceValue, 'Zoom', 'Zoom In')
+defaultPage.makeCommandBinding(surfaceElements.transport.zoomHorizOut.mSurfaceValue, 'Zoom', 'Zoom Out')
+
+// Start button
+// var startStatus = deviceDriver.mSurface.makeCustomValueVariable('startStatus')
+
+defaultPage.makeValueBinding(surfaceElements.transport.btnStart.mSurfaceValue, defaultPage.mHostAccess.mTransport.mValue.mStart).setTypeToggle()
+
+surfaceElements.transport.start_state.mOnProcessValueChange = function (activeDevice, value) {
+    // Only send on press - process value change will be received for both press (1)and release (0)
+    if (value == 1) {
+        // console.log('Start pressed')
+        surfaceElements.transport.btnStart.mSurfaceValue.setProcessValue(activeDevice, value)
+    }
+}
 
 // Jog Knob
 var jogLeftVariable = deviceDriver.mSurface.makeCustomValueVariable('jogLeft')
 var jogRightVariable = deviceDriver.mSurface.makeCustomValueVariable('jogRight')
 
-page.makeCommandBinding(jogLeftVariable, 'Transport', 'Nudge Cursor Left')
-page.makeCommandBinding(jogRightVariable, 'Transport', 'Nudge Cursor Right')
+defaultPage.makeCommandBinding(jogLeftVariable, 'Transport', 'Nudge Cursor Left')
+defaultPage.makeCommandBinding(jogRightVariable, 'Transport', 'Nudge Cursor Right')
 
 createCommandKnob(surfaceElements.transport.jog_wheel, jogRightVariable, jogLeftVariable);
 
-
 function repeatCommand(activeDevice, command, repeats) {
-    for(var i = 0; i < repeats; i++) {
+    for (var i = 0; i < repeats; i++) {
         command.setProcessValue(activeDevice, 1)
     }
 }
@@ -201,14 +193,14 @@ function repeatCommand(activeDevice, command, repeats) {
  */
 function createCommandKnob(pushEncoder, commandIncrease, commandDecrease) {
     // console.log('from script: createCommandKnob')
-    pushEncoder.mEncoderValue.mOnProcessValueChange = function(activeDevice, value) {
-      console.log('value changed: ' + value)
-      if(value < 0.5 ) {
-        var jump_rate = Math.floor(value*127)
-        repeatCommand(activeDevice, commandIncrease, jump_rate)
-      } else if (value > 0.5) {
-        var jump_rate = Math.floor((value-0.5)*127)
-        repeatCommand(activeDevice, commandDecrease, jump_rate)
-      }
+    pushEncoder.mEncoderValue.mOnProcessValueChange = function (activeDevice, value) {
+        console.log('value changed: ' + value)
+        if (value < 0.5) {
+            var jump_rate = Math.floor(value * 127)
+            repeatCommand(activeDevice, commandIncrease, jump_rate)
+        } else if (value > 0.5) {
+            var jump_rate = Math.floor((value - 0.5) * 127)
+            repeatCommand(activeDevice, commandDecrease, jump_rate)
+        }
     }
-  }
+}

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -185,7 +185,11 @@ function makePageMixer() {
         var rec_buttonSurfaceValue = surfaceElements.channelControls[channelIndex].rec_button.mSurfaceValue;
 
         // Displays
+        // PC
+        // ? There doesn't appear to be a way via relateTo to connect the label surface elements to valueTitle or arbitrarily change them around
+        // ! Ignoring PC side of display for the moment in favour of the D2 displaying what is required
         page.setLabelFieldHostObject(surfaceElements.channelControls[channelIndex].displayTop, hostMixerBankChannel) // For PC display, Platfomr M+ D2 display coded in icon_elements.js
+        // D2
         page.makeValueBinding(surfaceElements.channelControls[channelIndex].faderValueDisplay, hostMixerBankChannel.mValue.mVolume) // for Platform M+ D2 Display
         page.makeValueBinding(surfaceElements.channelControls[channelIndex].panValueDisplay, hostMixerBankChannel.mValue.mPan) // for Platform M+ D2 Display
 
@@ -193,8 +197,7 @@ function makePageMixer() {
         page.makeValueBinding(knobSurfaceValue, hostMixerBankChannel.mValue.mPan).setSubPage(subPageFaderVolume)
         page.makeValueBinding(knobPushValue, hostMixerBankChannel.mValue.mEditorOpen).setTypeToggle().setSubPage(subPageFaderVolume)
         page.makeValueBinding(faderSurfaceValue, hostMixerBankChannel.mValue.mVolume).setValueTakeOverModeJump().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(faderTouchSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageFaderVolume)
-        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mMonitorEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)
+        page.makeValueBinding(sel_buttonSurfaceValue, hostMixerBankChannel.mValue.mSelected).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(mute_buttonSurfaceValue, hostMixerBankChannel.mValue.mMute).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(solo_buttonSurfaceValue, hostMixerBankChannel.mValue.mSolo).setTypeToggle().setSubPage(subPageButtonDefaultSet)
         page.makeValueBinding(rec_buttonSurfaceValue, hostMixerBankChannel.mValue.mRecordEnable).setTypeToggle().setSubPage(subPageButtonDefaultSet)

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -4,7 +4,7 @@
 // Portions of this implementation where inspired by other midi remote creates to whom I wish to say thank you!
 // - Mackie C4 by Ron Garrison <ron.garrison@gmail.com> https://github.com/rwgarrison/midiremote-userscripts
 
-var sw_rev = '0.0.0'
+var sw_rev = '0.0.1'
 
 var iconElements = require('./icon_elements.js');
 var channelControl = iconElements.channelControl;
@@ -28,9 +28,9 @@ var midiOutput = deviceDriver.mPorts.makeMidiOutput()
 // define all possible namings the devices MIDI ports could have
 // NOTE: Windows and MacOS handle port naming differently
 deviceDriver.makeDetectionUnit().detectPortPair(midiInput, midiOutput)
-    .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonOut
-    .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15 PlatformMonIn
-.
+    .expectInputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
+    .expectOutputNameEquals('Platform M+ V2.15') // Platform M+ v2.15
+
 var surface = deviceDriver.mSurface
 
 //-----------------------------------------------------------------------------

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -135,7 +135,51 @@ function makeSubPage(subPageArea, name) {
                 midiOutput.sendMidi(activeDevice, [0x90, 2, 0])
                 midiOutput.sendMidi(activeDevice, [0x90, 3, 127])
                 break;
-
+            case "Gate":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 24, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                break;
+            case "Compressor":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 25, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                break;
+            case "Tools":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 26, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                break;
+            case "Saturator":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 27, 127])
+                midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+                break;
+            case "Limiter":
+                // An action binding cannot be set to ta Toggle type button so manually adjust the sel button lights
+                // based on the subpage selection.
+                midiOutput.sendMidi(activeDevice, [0x90, 24, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+                midiOutput.sendMidi(activeDevice, [0x90, 28, 127])
+                break;
         }
         Helper_updateDisplay('Row1', 'Row2', 'AltRow1', 'AltRow2', activeDevice, midiOutput)
     }).bind({ subPage, name })
@@ -365,66 +409,49 @@ function makePageSelectedTrack() {
     return page
 }
 
-// function makePageChannelStrip() {
-//     var page = makePageWithDefaults('Channelstrip')
+function makePageChannelStrip() {
+    var page = makePageWithDefaults('Channelstrip')
 
-//     var strip = page.makeSubPageArea('strip')
-//     var gatePage = makeSubPage(strip, 'Gate')
-//     var compressorPage = makeSubPage(strip, 'Compressor')
-//     var toolsPage = makeSubPage(strip, 'Tools')
-//     var saturatorPage = makeSubPage(strip, 'Saturator')
-//     var limiterPage = makeSubPage(strip, 'Limiter')
+    var strip = page.makeSubPageArea('Strip')
+    var gatePage = makeSubPage(strip, 'Gate')
+    var compressorPage = makeSubPage(strip, 'Compressor')
+    var toolsPage = makeSubPage(strip, 'Tools')
+    var saturatorPage = makeSubPage(strip, 'Saturator')
+    var limiterPage = makeSubPage(strip, 'Limiter')
 
 
-//     var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
-//     var stripEffects = selectedTrackChannel.mInsertAndStripEffects.mStripEffects
+    var selectedTrackChannel = page.mHostAccess.mTrackSelection.mMixerChannel
+    var stripEffects = selectedTrackChannel.mInsertAndStripEffects.mStripEffects
 
-//     for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
-//         var knobSurfaceValue = surfaceElements.channelControls[idx].pushEncoder.mEncoderValue;
-//         var knobPushValue = surfaceElements.channelControls[idx].pushEncoder.mPushValue;
-//         var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
+    for (var idx = 0; idx < surfaceElements.numStrips; ++idx) {
+        var faderSurfaceValue = surfaceElements.channelControls[idx].fader.mSurfaceValue;
 
-//         page.makeValueBinding(faderSurfaceValue, stripEffects.mGate.mParameterBankZone.makeParameterValue()).setSubPage(gatePage)
-//         page.makeValueBinding(faderSurfaceValue, stripEffects.mCompressor.mParameterBankZone.makeParameterValue()).setSubPage(compressorPage)
-//         page.makeValueBinding(faderSurfaceValue, stripEffects.mTools.mParameterBankZone.makeParameterValue()).setSubPage(toolsPage)
-//         page.makeValueBinding(faderSurfaceValue, stripEffects.mSaturator.mParameterBankZone.makeParameterValue()).setSubPage(saturatorPage)
-//         page.makeValueBinding(faderSurfaceValue, stripEffects.mLimiter.mParameterBankZone.makeParameterValue()).setSubPage(limiterPage)
-//     }
+        page.makeValueBinding(faderSurfaceValue, stripEffects.mGate.mParameterBankZone.makeParameterValue()).setSubPage(gatePage)
+        page.makeValueBinding(faderSurfaceValue, stripEffects.mCompressor.mParameterBankZone.makeParameterValue()).setSubPage(compressorPage)
+        page.makeValueBinding(faderSurfaceValue, stripEffects.mTools.mParameterBankZone.makeParameterValue()).setSubPage(toolsPage)
+        page.makeValueBinding(faderSurfaceValue, stripEffects.mSaturator.mParameterBankZone.makeParameterValue()).setSubPage(saturatorPage)
+        page.makeValueBinding(faderSurfaceValue, stripEffects.mLimiter.mParameterBankZone.makeParameterValue()).setSubPage(limiterPage)
+    }
 
-//     for (var idx = 0; idx < 5; ++idx) {
-//         var faderStrip = surfaceElements.channelControls[idx]
-//         var type = ['mGate', 'mCompressor', 'mTools', 'mSaturator', 'mLimiter'][idx]
-//         page.makeValueBinding(faderStrip.rec_button.mSurfaceValue, stripEffects[type].mOn).setTypeToggle()
-//         page.makeValueBinding(faderStrip.mute_button.mSurfaceValue, stripEffects[type].mBypass).setTypeToggle()
-//     }
+    for (var idx = 0; idx < 5; ++idx) {
+        var faderStrip = surfaceElements.channelControls[idx]
+        var type = ['mGate', 'mCompressor', 'mTools', 'mSaturator', 'mLimiter'][idx]
+        page.makeValueBinding(faderStrip.rec_button.mSurfaceValue, stripEffects[type].mOn).setTypeToggle()
+        page.makeValueBinding(faderStrip.mute_button.mSurfaceValue, stripEffects[type].mBypass).setTypeToggle()
+    }
 
-//     page.makeActionBinding(surfaceElements.channelControls[0].sel_button.mSurfaceValue, gatePage.mAction.mActivate)
-//     page.makeActionBinding(surfaceElements.channelControls[1].sel_button.mSurfaceValue, compressorPage.mAction.mActivate)
-//     page.makeActionBinding(surfaceElements.channelControls[2].sel_button.mSurfaceValue, toolsPage.mAction.mActivate)
-//     page.makeActionBinding(surfaceElements.channelControls[3].sel_button.mSurfaceValue, saturatorPage.mAction.mActivate)
-//     page.makeActionBinding(surfaceElements.channelControls[4].sel_button.mSurfaceValue, limiterPage.mAction.mActivate)
+    page.makeActionBinding(surfaceElements.channelControls[0].sel_button.mSurfaceValue, gatePage.mAction.mActivate)
+    page.makeActionBinding(surfaceElements.channelControls[1].sel_button.mSurfaceValue, compressorPage.mAction.mActivate)
+    page.makeActionBinding(surfaceElements.channelControls[2].sel_button.mSurfaceValue, toolsPage.mAction.mActivate)
+    page.makeActionBinding(surfaceElements.channelControls[3].sel_button.mSurfaceValue, saturatorPage.mAction.mActivate)
+    page.makeActionBinding(surfaceElements.channelControls[4].sel_button.mSurfaceValue, limiterPage.mAction.mActivate)
 
-//     gatePage.mOnActivate = function (device) { setLeds(device, 24, 'Gate') }
-//     compressorPage.mOnActivate = function (device) { setLeds(device, 25, 'Compressor') }
-//     toolsPage.mOnActivate = function (device) { setLeds(device, 26, 'Tools') }
-//     saturatorPage.mOnActivate = function (device) { setLeds(device, 27, 'Saturator') }
-//     limiterPage.mOnActivate = function (device) { setLeds(device, 28, 'Limiter') }
-
-//     function setLeds(device, value, text) {
-//         console.log('from script: Platform M+ subpage "' + text + '" activated')
-//         for (var i = 0; i < 5; ++i) {
-//             midiOutput.sendMidi(device, [0x90, 24 + i, 0])
-//         }
-//         midiOutput.sendMidi(device, [0x90, value, 127])
-//     }
-
-//     return page
-// }
+    return page
+}
 
 var mixerPage = makePageMixer()
 var selectedTrackPage = makePageSelectedTrack()
-// WIP Add Channel Strip Page
-// var channelStripPage = makePageChannelStrip()
+var channelStripPage = makePageChannelStrip()
 // WIP Add Control Room Page
 // WIP Add MIDI CC Page and extra MIDI Port
 
@@ -464,11 +491,16 @@ selectedTrackPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeD
     midiOutput.sendMidi(activeDevice, [0x90, 3, 0])
 }).bind({ midiOutput })
 
-// WIP Add Channel Strip Page
-// channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
-//     console.log('from script: Platform M+ page "Channel Strip" activated')
-//     activeDevice.setState("activePage", "ChannelStrip")
-//     clearAllLeds(activeDevice, midiOutput)
-//     clearChannelState(activeDevice)
-// }).bind({ midiOutput })
+channelStripPage.mOnActivate = (function (/** @type {MR_ActiveDevice} */activeDevice) {
+    console.log('from script: Platform M+ page "Channel Strip" activated')
+    activeDevice.setState("activePage", "ChannelStrip")
+    clearAllLeds(activeDevice, midiOutput)
+    clearChannelState(activeDevice)
+    activeDevice.setState("activeSubPage", "Gate")
+    midiOutput.sendMidi(activeDevice, [0x90, 24, 127])
+    midiOutput.sendMidi(activeDevice, [0x90, 25, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 26, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 27, 0])
+    midiOutput.sendMidi(activeDevice, [0x90, 28, 0])
+}).bind({ midiOutput })
 

--- a/icon/platformmplus/icon_platformmplus.js
+++ b/icon/platformmplus/icon_platformmplus.js
@@ -208,16 +208,26 @@ function makePageSelectedTrack() {
         page.makeValueBinding(knobSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mLevel)
         page.makeValueBinding(knobPushValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
         page.makeValueBinding(faderSurfaceValue, page.mHostAccess.mFocusedQuickControls.getByIndex(idx)).setValueTakeOverModeJump()
+
+        //page.makeValueBinding(surfaceElements.channelControls[idx].sel_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
+        page.makeValueBinding(surfaceElements.channelControls[idx].mute_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mPrePost).setTypeToggle()
+        //page.makeValueBinding(surfaceElements.channelControls[idx].solo_button.mSurfaceValue, selectedTrackChannel.mSends.getByIndex(idx).mOn).setTypeToggle()
     }
 
-    page.makeValueBinding(surfaceElements.channelControls[6].sel_button.mSurfaceValue, selectedTrackChannel.mValue.mEditorOpen).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[6].mute_button.mSurfaceValue, selectedTrackChannel.mValue.mInstrumentOpen).setTypeToggle()
-    page.makeCommandBinding(surfaceElements.channelControls[6].solo_button.mSurfaceValue, 'Automation', 'Show Used Automation (Selected Tracks)')
-    page.makeCommandBinding(surfaceElements.channelControls[6].rec_button.mSurfaceValue, 'Automation', 'Hide Automation')
+    page.makeValueBinding(surfaceElements.channelControls[0].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand1.mOn).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[1].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand2.mOn).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[2].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand3.mOn).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[3].solo_button.mSurfaceValue, selectedTrackChannel.mChannelEQ.mBand4.mOn).setTypeToggle()
 
-    page.makeValueBinding(surfaceElements.channelControls[7].sel_button.mSurfaceValue, selectedTrackChannel.mValue.mMonitorEnable).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[7].mute_button.mSurfaceValue, selectedTrackChannel.mValue.mMute).setTypeToggle()
-    page.makeValueBinding(surfaceElements.channelControls[7].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mSolo).setTypeToggle()
+
+    page.makeCommandBinding(surfaceElements.channelControls[4].solo_button.mSurfaceValue, 'Automation', 'Show Used Automation (Selected Tracks)')
+    page.makeCommandBinding(surfaceElements.channelControls[5].solo_button.mSurfaceValue, 'Automation', 'Hide Automation')
+    page.makeValueBinding(surfaceElements.channelControls[6].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mEditorOpen).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[7].solo_button.mSurfaceValue, selectedTrackChannel.mValue.mInstrumentOpen).setTypeToggle()
+
+    page.makeValueBinding(surfaceElements.channelControls[4].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMonitorEnable).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[5].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mMute).setTypeToggle()
+    page.makeValueBinding(surfaceElements.channelControls[6].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mSolo).setTypeToggle()
     page.makeValueBinding(surfaceElements.channelControls[7].rec_button.mSurfaceValue, selectedTrackChannel.mValue.mRecordEnable).setTypeToggle()
 
     return page


### PR DESCRIPTION
This is an Icon Platform M+ (in MCU Mode) Midi remote script with:

1. Mixer Pager
2. Selected Channel Page with sub pages for
   - Sends and Quick Controls
   - EQ
   - Pre Filter
   - Cue Sends
3. Transport Controls (common to all pages:
   - Jog Wheel Functions as Jog, Nudge Cursor, Zoom in/out (Horizontal and Vertical), Next/Prev Event, and Jog back/forth
   - Jog wheel is turn speed sensitive - turn faster, nudge more, turn slower, nudge less (same for other functions)

Known Issue:
When first started in any new session the Midi Remote will show correctly but when a function is pressed (e.g. select Channel when on the Mixer Page, or simply select a channel in Cubase with the mouse) the Midi Remote will grey out and disconnect.
When this happens selecting a Channel in Cubase (or pushing one of the remaining controls active in the Midi remote on the transport section) will refresh the midi remote - ALL functions will then work normally for the rest of the session.

I'm of the view this is a Bug in the Midi Remote engine as its completely reproducible in other midi remote script implementations. Looks to me like something is not being initialized correctly and it takes a couple of channel selections to fix it.

I've also noticed when first connected the midi remote will initialize to Mixer Bank 1, even if your Selected Channel in Cubase is in a completely different bank.

Definitely have some additional features I'd like to see (multi track automation so I can selected 4 tracks (SATB) and then have QC1/2 for Selection 1, QC1/2 for Selection 2 ... That way I can automate an SATB instrument section all in one hit. Be great to have the ability to map to/from CC's in general rather than just QC (though I do like QC for fader automation of course. - which reminds me, I need to check if QC automation works with Note Expression and similar note+CC editing functions. Gonna be a pest for orchestral expression if they don't!). 

Great start thought, really looking forward to more.

Cheers,

Rob
